### PR TITLE
🌼 Release v2.1.0 - Rapeseed branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2025-12-26
+
+### Added
+- 🌼 **Rapeseed Branding**: RAPS now stands for "Rust Autodesk Platform Services" with the blossom (🌼) as the brand symbol.
+- **Official Website**: New documentation and blog at [rapscli.xyz](https://rapscli.xyz).
+- **Blossom Favicon**: Updated website favicon with golden blossom design.
+
+### Changed
+- **CLI Branding**: Updated `--version` and `--help` output to show "🌼 RAPS (rapeseed)" branding.
+- **Documentation Links**: All documentation now points to [rapscli.xyz](https://rapscli.xyz).
+- **Cargo.toml**: Updated homepage, documentation URLs, and description with rapeseed branding.
+- **Package Managers**: Updated Homebrew and Scoop formulas with new branding and homepage.
+
+---
+
 ## [2.0.0] - 2025-12-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raps"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "🌼 RAPS (rapeseed) — Rust Autodesk Platform Services CLI"
 authors = ["Dmytro Yemelianov"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ use output::OutputFormat;
 #[derive(Parser)]
 #[command(name = "raps")]
 #[command(author = "Dmytro Yemelianov <https://rapscli.xyz>")]
-#[command(version = "2.0.0")]
+#[command(version = "2.1.0")]
 #[command(about = "🌼 RAPS (rapeseed) — Rust Autodesk Platform Services CLI", long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {


### PR DESCRIPTION
## 🌼 Release v2.1.0 - Rapeseed Branding

### What's New

- **🌼 Rapeseed Branding**: RAPS now stands for **R**ust **A**utodesk **P**latform **S**ervices with the blossom (🌼) as the brand symbol
- **Official Website**: [rapscli.xyz](https://rapscli.xyz) is now live!
- **Updated CLI**: \--version\ and \--help\ now show rapeseed branding

### Changes

- Updated \Cargo.toml\ with new homepage and description
- Updated \main.rs\ CLI metadata with 🌼 branding  
- Updated \CHANGELOG.md\ with v2.1.0 release notes
- All documentation links now point to rapscli.xyz

### Package Manager Updates

- Homebrew formula updated
- Scoop bucket updated
- Docker image updated