### PR TITLE
feat: trigger package manager updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trigger Docker build
+        if: ${{ !contains(steps.get_version.outputs.version, '-') }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_TRIGGER_TOKEN }}
+          repository: dmytro-yemelianov/raps-docker
+          event-type: raps-release
+          client-payload: '{"version": "${{ steps.get_version.outputs.version }}"}'
+
+      - name: Trigger Homebrew update
+        if: ${{ !contains(steps.get_version.outputs.version, '-') }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_TRIGGER_TOKEN }}
+          repository: dmytro-yemelianov/homebrew-tap
+          event-type: raps-release
+          client-payload: '{"version": "${{ steps.get_version.outputs.version }}"}'
+
+      - name: Trigger Scoop update
+        if: ${{ !contains(steps.get_version.outputs.version, '-') }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_TRIGGER_TOKEN }}
+          repository: dmytro-yemelianov/scoop-bucket
+          event-type: raps-release
+          client-payload: '{"version": "${{ steps.get_version.outputs.version }}"}'
+


### PR DESCRIPTION
Automatically triggers updates for all distribution channels when a new stable version is released:

## Channels Triggered
- **DockerHub** (dmytroyemelianov/raps)
- **GHCR** (ghcr.io/dmytro-yemelianov/raps)
- **Homebrew** (dmytro-yemelianov/tap)
- **Scoop** (dmytro-yemelianov/scoop-bucket)

## How It Works
On release, the workflow sends repository_dispatch events to each channel's repo, which then:
1. Downloads the release artifacts
2. Computes checksums
3. Updates the formula/manifest
4. Commits and pushes

## Required Secret
\RELEASE_TRIGGER_TOKEN\ - PAT with repo dispatch permissions for all channel repos