### PR TITLE
Release 2.2.0 with derivative traversal fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2025-12-27
+
+### Fixed
+- Removed unnecessary self-recursion in derivative download collection helpers to satisfy linting and simplify traversal.
+- Optimized derivative format filtering to avoid repeated string allocations while keeping case-insensitive comparisons.
+
 ## [2.1.0] - 2025-12-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "raps"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raps"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 description = "🌼 RAPS (rapeseed) — Rust Autodesk Platform Services CLI"
 authors = ["Dmytro Yemelianov"]

--- a/src/api/derivative.rs
+++ b/src/api/derivative.rs
@@ -402,7 +402,7 @@ impl DerivativeClient {
         let mut downloadables = Vec::new();
 
         for derivative in &manifest.derivatives {
-            self.collect_downloadables(derivative, &derivative.output_type, &mut downloadables);
+            Self::collect_downloadables(derivative, &derivative.output_type, &mut downloadables);
         }
 
         Ok(downloadables)
@@ -410,19 +410,17 @@ impl DerivativeClient {
 
     /// Recursively collect downloadable items from derivative tree
     fn collect_downloadables(
-        &self,
         derivative: &Derivative,
         output_type: &str,
         downloadables: &mut Vec<DownloadableDerivative>,
     ) {
         for child in &derivative.children {
-            self.collect_downloadables_from_child(child, output_type, downloadables);
+            Self::collect_downloadables_from_child(child, output_type, downloadables);
         }
     }
 
     /// Recursively collect downloadable items from child nodes
     fn collect_downloadables_from_child(
-        &self,
         child: &DerivativeChild,
         output_type: &str,
         downloadables: &mut Vec<DownloadableDerivative>,
@@ -451,7 +449,7 @@ impl DerivativeClient {
 
         // Recurse into children
         for grandchild in &child.children {
-            self.collect_downloadables_from_child(grandchild, output_type, downloadables);
+            Self::collect_downloadables_from_child(grandchild, output_type, downloadables);
         }
     }
 
@@ -460,9 +458,11 @@ impl DerivativeClient {
         derivatives: &[DownloadableDerivative],
         format: &str,
     ) -> Vec<DownloadableDerivative> {
+        let target_format = format.to_ascii_lowercase();
+
         derivatives
             .iter()
-            .filter(|d| d.output_type.to_lowercase() == format.to_lowercase())
+            .filter(|d| d.output_type.to_ascii_lowercase() == target_format)
             .cloned()
             .collect()
     }


### PR DESCRIPTION
## Summary
- remove the unnecessary self-recursive methods in derivative download collection helpers
- optimize derivative format filtering to avoid repeated allocations while keeping case-insensitive matching
- bump the crate version to 2.2.0 and record the changes in the changelog

## Testing
- cargo clippy -- -D warnings
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fbab990f88329943bcb237b707668)