### PR TITLE
Release v3.0.0 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0] - 2025-12-27
-
 ### Changed
 - Hardened MCP server tool invocation with strict argument validation, safer defaults, and clearer errors to prevent invalid API calls.
 - Cached APS client instances to reduce lock contention and repeated client construction during MCP sessions.
 - Added sensible limit clamping and output format validation to MCP tools to mitigate abusive requests and clarify supported conversions.
 
-## [3.0.0] - 2025-12-26
+## [3.0.0] - 2025-12-27
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raps"
-version = "4.0.0"
+version = "3.0.0"
 edition = "2021"
 description = "🌼 RAPS (rapeseed) — Rust Autodesk Platform Services CLI"
 authors = ["Dmytro Yemelianov"]


### PR DESCRIPTION
Updates Cargo.toml version to 3.0.0 and adjusts CHANGELOG for the v3.0.0 release.