### PR TITLE
feat(api): add custom API calls for CLI and MCP

### DIFF
--- a/raps-acc/src/admin.rs
+++ b/raps-acc/src/admin.rs
@@ -9,7 +9,9 @@ use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
 
-use crate::types::{AccountProject, AccountUser, PaginatedResponse};
+use serde::Serialize;
+
+use crate::types::{AccountProject, AccountUser, PaginatedResponse, ProjectClassification};
 
 /// Client for ACC Account Admin API
 ///
@@ -289,14 +291,447 @@ impl AccountAdminClient {
 
         Ok(all_projects)
     }
+
+    // ========================================================================
+    // TEMPLATE OPERATIONS
+    // ========================================================================
+
+    /// List project templates in an account (paginated)
+    ///
+    /// Templates are projects with classification="template".
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `limit` - Maximum results per page (max: 200)
+    /// * `offset` - Starting index
+    pub async fn list_templates(
+        &self,
+        account_id: &str,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Result<PaginatedResponse<AccountProject>> {
+        self.list_projects_filtered(
+            account_id,
+            Some(ProjectClassification::Template),
+            None,
+            limit,
+            offset,
+        )
+        .await
+    }
+
+    /// List projects with optional classification and name filters
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `classification` - Filter by project classification (template, production, etc.)
+    /// * `name_filter` - Filter by project name (partial match)
+    /// * `limit` - Maximum results per page (max: 200)
+    /// * `offset` - Starting index
+    pub async fn list_projects_filtered(
+        &self,
+        account_id: &str,
+        classification: Option<ProjectClassification>,
+        name_filter: Option<&str>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Result<PaginatedResponse<AccountProject>> {
+        let token = self.auth.get_3leg_token().await?;
+        let account_id = normalize_account_id(account_id);
+
+        let mut url = format!("{}/projects", self.admin_url(&account_id));
+
+        // Build query parameters
+        let mut params = Vec::new();
+        if let Some(l) = limit {
+            params.push(format!("limit={}", l.min(200)));
+        }
+        if let Some(o) = offset {
+            params.push(format!("offset={}", o));
+        }
+        if let Some(c) = classification {
+            params.push(format!("filter[classification]={}", c));
+        }
+        if let Some(name) = name_filter {
+            params.push(format!("filter[name]={}", urlencoding::encode(name)));
+        }
+        if !params.is_empty() {
+            url = format!("{}?{}", url, params.join("&"));
+        }
+
+        let response = self
+            .http_client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("Failed to list projects")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("Failed to list projects ({status}): {error_text}");
+        }
+
+        let projects_response: PaginatedResponse<AccountProject> = response
+            .json()
+            .await
+            .context("Failed to parse projects response")?;
+
+        Ok(projects_response)
+    }
+
+    /// Fetch all templates in an account (handles pagination automatically)
+    pub async fn list_all_templates(&self, account_id: &str) -> Result<Vec<AccountProject>> {
+        let mut all_templates = Vec::new();
+        let mut offset = 0;
+        let limit = 200;
+
+        loop {
+            let response = self
+                .list_templates(account_id, Some(limit), Some(offset))
+                .await?;
+            let has_more = response.has_more();
+            let next_offset = response.next_offset();
+            all_templates.extend(response.results);
+
+            if !has_more {
+                break;
+            }
+            offset = next_offset;
+        }
+
+        Ok(all_templates)
+    }
+
+    // ========================================================================
+    // PROJECT CREATE/UPDATE/DELETE
+    // ========================================================================
+
+    /// Create a new project in an account
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `request` - Project creation parameters
+    ///
+    /// # Returns
+    /// The created project (may be in pending status initially)
+    pub async fn create_project(
+        &self,
+        account_id: &str,
+        request: CreateProjectRequest,
+    ) -> Result<AccountProject> {
+        let token = self.auth.get_3leg_token().await?;
+        let account_id = normalize_account_id(account_id);
+
+        let url = format!("{}/projects", self.admin_url(&account_id));
+
+        let response = self
+            .http_client
+            .post(&url)
+            .bearer_auth(&token)
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to create project")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("Failed to create project ({status}): {error_text}");
+        }
+
+        let project: AccountProject = response
+            .json()
+            .await
+            .context("Failed to parse project creation response")?;
+
+        Ok(project)
+    }
+
+    /// Update an existing project
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `project_id` - The project ID to update
+    /// * `request` - Update parameters
+    pub async fn update_project(
+        &self,
+        account_id: &str,
+        project_id: &str,
+        request: UpdateProjectRequest,
+    ) -> Result<AccountProject> {
+        let token = self.auth.get_3leg_token().await?;
+        let account_id = normalize_account_id(account_id);
+        let project_id = normalize_project_id(project_id);
+
+        let url = format!("{}/projects/{}", self.admin_url(&account_id), project_id);
+
+        let response = self
+            .http_client
+            .patch(&url)
+            .bearer_auth(&token)
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to update project")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("Failed to update project ({status}): {error_text}");
+        }
+
+        let project: AccountProject = response
+            .json()
+            .await
+            .context("Failed to parse project update response")?;
+
+        Ok(project)
+    }
+
+    /// Archive a project (soft delete)
+    ///
+    /// Projects cannot be permanently deleted via API. Archiving sets status to "archived".
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `project_id` - The project ID to archive
+    pub async fn archive_project(&self, account_id: &str, project_id: &str) -> Result<()> {
+        let request = UpdateProjectRequest {
+            status: Some("archived".to_string()),
+            ..Default::default()
+        };
+        self.update_project(account_id, project_id, request).await?;
+        Ok(())
+    }
+
+    /// Wait for a project to become active
+    ///
+    /// Polls the project status until it becomes active or times out.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `project_id` - The project ID to wait for
+    /// * `timeout_secs` - Maximum time to wait (default: 120 seconds)
+    /// * `poll_interval_ms` - Time between polls (default: 3000ms)
+    pub async fn wait_for_project_active(
+        &self,
+        account_id: &str,
+        project_id: &str,
+        timeout_secs: Option<u64>,
+        poll_interval_ms: Option<u64>,
+    ) -> Result<AccountProject> {
+        let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(120));
+        let poll_interval = std::time::Duration::from_millis(poll_interval_ms.unwrap_or(3000));
+        let start = std::time::Instant::now();
+
+        loop {
+            if start.elapsed() > timeout {
+                anyhow::bail!(
+                    "Timeout waiting for project {} to become active (waited {}s)",
+                    project_id,
+                    timeout.as_secs()
+                );
+            }
+
+            let project = self.get_project(account_id, project_id).await?;
+            let status = project.status.as_deref().unwrap_or("unknown");
+
+            match status.to_lowercase().as_str() {
+                "active" => return Ok(project),
+                "failed" | "error" => {
+                    anyhow::bail!("Project creation failed for project {}", project_id);
+                }
+                _ => {
+                    tokio::time::sleep(poll_interval).await;
+                }
+            }
+        }
+    }
 }
 
-/// Remove "b." prefix from account ID if present
+// ============================================================================
+// REQUEST TYPES
+// ============================================================================
+
+/// Request to create a new project
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateProjectRequest {
+    /// Project name (required)
+    pub name: String,
+    /// Project type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    /// Project classification (production, template, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classification: Option<ProjectClassification>,
+    /// Template configuration (for creating from template)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<TemplateConfig>,
+    /// Products to enable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub products: Option<Vec<String>>,
+    /// Project start date (ISO 8601)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+    /// Project end date (ISO 8601)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<String>,
+    /// Project value/budget
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+    /// Currency code (e.g., "USD")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    /// Project address line 1
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line1: Option<String>,
+    /// Project address line 2
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line2: Option<String>,
+    /// City
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    /// State/Province
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_or_province: Option<String>,
+    /// Postal code
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postal_code: Option<String>,
+    /// Country
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    /// Time zone
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+    /// Construction type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub construction_type: Option<String>,
+    /// Contract type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_type: Option<String>,
+}
+
+/// Template configuration for creating project from template
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateConfig {
+    /// ID of the template project to clone from
+    pub project_id: String,
+    /// Options for what to include when cloning
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<TemplateOptions>,
+}
+
+/// Options for template cloning
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateOptions {
+    /// Field-level options
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<TemplateFieldOptions>,
+}
+
+/// Field-level options for template cloning
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateFieldOptions {
+    /// Whether to copy company data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_companies: Option<bool>,
+    /// Whether to copy location data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_locations: Option<bool>,
+}
+
+/// Request to update an existing project
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateProjectRequest {
+    /// Project name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Project status (active, archived, suspended)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Project start date
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+    /// Project end date
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<String>,
+    /// Project type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    /// Project value/budget
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+    /// Currency code
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    /// Address line 1
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line1: Option<String>,
+    /// Address line 2
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line2: Option<String>,
+    /// City
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    /// State/Province
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_or_province: Option<String>,
+    /// Postal code
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postal_code: Option<String>,
+    /// Country
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    /// Time zone
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+}
+
+/// Normalize account ID to the format expected by ACC Admin API
+///
+/// Handles various input formats:
+/// - `b.{uuid}` (BIM 360 hub format) -> extracts uuid
+/// - `a.{base64}` (ACC hub format) -> decodes and extracts account ID
+/// - Raw UUID -> returns as-is
 fn normalize_account_id(account_id: &str) -> String {
-    account_id
-        .strip_prefix("b.")
-        .unwrap_or(account_id)
-        .to_string()
+    // Handle BIM 360 format: b.{uuid}
+    if let Some(id) = account_id.strip_prefix("b.") {
+        return id.to_string();
+    }
+
+    // Handle ACC format: a.{base64}
+    if let Some(encoded) = account_id.strip_prefix("a.")
+        && let Ok(decoded_bytes) = base64_decode(encoded)
+        && let Ok(decoded) = String::from_utf8(decoded_bytes)
+    {
+        // Format is typically "business:{account_id}" or just the account_id
+        if let Some(id) = decoded.strip_prefix("business:") {
+            return id.to_string();
+        }
+        // Try splitting on colon for other formats
+        if let Some((_, id)) = decoded.split_once(':') {
+            return id.to_string();
+        }
+        return decoded;
+    }
+
+    // Already a raw account ID
+    account_id.to_string()
+}
+
+/// Simple base64 decoder (URL-safe variant)
+fn base64_decode(input: &str) -> Result<Vec<u8>, ()> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    STANDARD.decode(input).map_err(|_| ())
 }
 
 /// Remove "b." prefix from project ID if present
@@ -313,8 +748,16 @@ mod tests {
 
     #[test]
     fn test_normalize_account_id() {
+        // BIM 360 format: b.{uuid}
         assert_eq!(normalize_account_id("b.123-456"), "123-456");
+        // Raw UUID
         assert_eq!(normalize_account_id("123-456"), "123-456");
+        // ACC format: a.{base64} where base64 decodes to "business:{account_id}"
+        // "YnVzaW5lc3M6Z21haWw2MDUzMTAz" decodes to "business:gmail6053103"
+        assert_eq!(
+            normalize_account_id("a.YnVzaW5lc3M6Z21haWw2MDUzMTAz"),
+            "gmail6053103"
+        );
     }
 
     #[test]

--- a/raps-cli/src/commands/api.rs
+++ b/raps-cli/src/commands/api.rs
@@ -1,0 +1,611 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 Dmytro Yemelianov
+
+//! Custom API call commands
+//!
+//! Execute arbitrary HTTP requests to APS API endpoints using the current authentication.
+//! Supports GET, POST, PUT, PATCH, DELETE methods with query parameters, request bodies,
+//! custom headers, and multiple output formats.
+
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+use colored::Colorize;
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::{Client, Method, Response, StatusCode};
+use serde::Serialize;
+use serde_json::Value;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::output::OutputFormat;
+use raps_kernel::auth::AuthClient;
+use raps_kernel::config::Config;
+use raps_kernel::http::{HttpClientConfig, is_allowed_url};
+use raps_kernel::logging;
+
+/// HTTP methods supported by the custom API command
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+impl HttpMethod {
+    /// Convert to reqwest Method
+    fn as_reqwest_method(self) -> Method {
+        match self {
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Delete => Method::DELETE,
+        }
+    }
+
+    /// Check if this method supports a request body
+    fn supports_body(self) -> bool {
+        matches!(self, HttpMethod::Post | HttpMethod::Put | HttpMethod::Patch)
+    }
+}
+
+
+/// Error response structure
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiError {
+    pub status_code: u16,
+    pub error_type: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+
+/// Custom API call commands
+#[derive(Debug, Subcommand)]
+pub enum ApiCommands {
+    /// Execute HTTP GET request
+    Get {
+        /// API endpoint path (e.g., /oss/v2/buckets)
+        endpoint: String,
+
+        /// Query parameter (KEY=VALUE, repeatable)
+        #[arg(long = "query", value_parser = parse_key_value)]
+        query: Vec<(String, String)>,
+
+        /// Custom header (KEY:VALUE, repeatable)
+        #[arg(short = 'H', long = "header", value_parser = parse_header)]
+        header: Vec<(String, String)>,
+
+        /// Save response to file
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Show response headers and status
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Execute HTTP POST request
+    Post {
+        /// API endpoint path (e.g., /oss/v2/buckets)
+        endpoint: String,
+
+        /// Inline JSON request body
+        #[arg(short, long, conflicts_with = "data_file")]
+        data: Option<String>,
+
+        /// Read request body from file
+        #[arg(short = 'f', long = "data-file", conflicts_with = "data")]
+        data_file: Option<PathBuf>,
+
+        /// Query parameter (KEY=VALUE, repeatable)
+        #[arg(long = "query", value_parser = parse_key_value)]
+        query: Vec<(String, String)>,
+
+        /// Custom header (KEY:VALUE, repeatable)
+        #[arg(short = 'H', long = "header", value_parser = parse_header)]
+        header: Vec<(String, String)>,
+
+        /// Save response to file
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Show response headers and status
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Execute HTTP PUT request
+    Put {
+        /// API endpoint path
+        endpoint: String,
+
+        /// Inline JSON request body
+        #[arg(short, long, conflicts_with = "data_file")]
+        data: Option<String>,
+
+        /// Read request body from file
+        #[arg(short = 'f', long = "data-file", conflicts_with = "data")]
+        data_file: Option<PathBuf>,
+
+        /// Query parameter (KEY=VALUE, repeatable)
+        #[arg(long = "query", value_parser = parse_key_value)]
+        query: Vec<(String, String)>,
+
+        /// Custom header (KEY:VALUE, repeatable)
+        #[arg(short = 'H', long = "header", value_parser = parse_header)]
+        header: Vec<(String, String)>,
+
+        /// Save response to file
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Show response headers and status
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Execute HTTP PATCH request
+    Patch {
+        /// API endpoint path
+        endpoint: String,
+
+        /// Inline JSON request body
+        #[arg(short, long, conflicts_with = "data_file")]
+        data: Option<String>,
+
+        /// Read request body from file
+        #[arg(short = 'f', long = "data-file", conflicts_with = "data")]
+        data_file: Option<PathBuf>,
+
+        /// Query parameter (KEY=VALUE, repeatable)
+        #[arg(long = "query", value_parser = parse_key_value)]
+        query: Vec<(String, String)>,
+
+        /// Custom header (KEY:VALUE, repeatable)
+        #[arg(short = 'H', long = "header", value_parser = parse_header)]
+        header: Vec<(String, String)>,
+
+        /// Save response to file
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Show response headers and status
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Execute HTTP DELETE request
+    Delete {
+        /// API endpoint path
+        endpoint: String,
+
+        /// Query parameter (KEY=VALUE, repeatable)
+        #[arg(long = "query", value_parser = parse_key_value)]
+        query: Vec<(String, String)>,
+
+        /// Custom header (KEY:VALUE, repeatable)
+        #[arg(short = 'H', long = "header", value_parser = parse_header)]
+        header: Vec<(String, String)>,
+
+        /// Show response headers and status
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+impl ApiCommands {
+    /// Execute the API command
+    pub async fn execute(
+        self,
+        config: &Config,
+        auth_client: &AuthClient,
+        http_config: &HttpClientConfig,
+        output_format: OutputFormat,
+    ) -> Result<()> {
+        // Extract common parameters based on variant
+        let (method, endpoint, query, headers, data, data_file, output_file, verbose) = match self {
+            ApiCommands::Get {
+                endpoint,
+                query,
+                header,
+                output,
+                verbose,
+            } => (HttpMethod::Get, endpoint, query, header, None, None, output, verbose),
+
+            ApiCommands::Post {
+                endpoint,
+                data,
+                data_file,
+                query,
+                header,
+                output,
+                verbose,
+            } => (HttpMethod::Post, endpoint, query, header, data, data_file, output, verbose),
+
+            ApiCommands::Put {
+                endpoint,
+                data,
+                data_file,
+                query,
+                header,
+                output,
+                verbose,
+            } => (HttpMethod::Put, endpoint, query, header, data, data_file, output, verbose),
+
+            ApiCommands::Patch {
+                endpoint,
+                data,
+                data_file,
+                query,
+                header,
+                output,
+                verbose,
+            } => (HttpMethod::Patch, endpoint, query, header, data, data_file, output, verbose),
+
+            ApiCommands::Delete {
+                endpoint,
+                query,
+                header,
+                verbose,
+            } => (HttpMethod::Delete, endpoint, query, header, None, None, None, verbose),
+        };
+
+        // Build full URL from endpoint
+        let full_url = build_url(&config.base_url, &endpoint, &query)?;
+
+        // Validate URL is allowed
+        if !is_allowed_url(&full_url) {
+            bail!(
+                "Only APS API endpoints are allowed. Use a path like /oss/v2/buckets\n\
+                 Hint: External URLs are not permitted for security reasons."
+            );
+        }
+
+        // Parse request body if provided
+        let body = parse_body(method, data, data_file)?;
+
+        // Get auth token
+        let token = get_auth_token(auth_client).await?;
+
+        // Build and execute request
+        let client = http_config.create_client()?;
+        let response = execute_request(
+            &client,
+            method,
+            &full_url,
+            &token,
+            &headers,
+            body.as_ref(),
+        )
+        .await?;
+
+        // Handle response
+        handle_response(response, output_format, output_file, verbose).await
+    }
+}
+
+/// Parse KEY=VALUE format for query parameters
+fn parse_key_value(s: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = s.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid format '{}'. Expected KEY=VALUE",
+            s
+        ));
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+/// Parse KEY:VALUE format for headers
+fn parse_header(s: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = s.splitn(2, ':').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid header format '{}'. Expected KEY:VALUE (e.g., Content-Type:application/json)",
+            s
+        ));
+    }
+    Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
+}
+
+/// Build full URL from base URL, endpoint, and query parameters
+fn build_url(base_url: &str, endpoint: &str, query_params: &[(String, String)]) -> Result<String> {
+    // Handle relative vs absolute endpoints
+    let mut url = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else {
+        // Ensure endpoint starts with /
+        let endpoint = if endpoint.starts_with('/') {
+            endpoint.to_string()
+        } else {
+            format!("/{}", endpoint)
+        };
+        format!("{}{}", base_url.trim_end_matches('/'), endpoint)
+    };
+
+    // Append query parameters
+    if !query_params.is_empty() {
+        let query_string: String = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        if url.contains('?') {
+            url = format!("{}&{}", url, query_string);
+        } else {
+            url = format!("{}?{}", url, query_string);
+        }
+    }
+
+    Ok(url)
+}
+
+/// Parse and validate request body from --data or --data-file
+fn parse_body(
+    method: HttpMethod,
+    data: Option<String>,
+    data_file: Option<PathBuf>,
+) -> Result<Option<Value>> {
+    // Check if body is allowed for this method
+    if !method.supports_body() {
+        if data.is_some() || data_file.is_some() {
+            bail!(
+                "Request body is not allowed for {} requests",
+                match method {
+                    HttpMethod::Get => "GET",
+                    HttpMethod::Delete => "DELETE",
+                    _ => unreachable!(),
+                }
+            );
+        }
+        return Ok(None);
+    }
+
+    // Read body from data or file
+    let body_str = if let Some(data) = data {
+        Some(data)
+    } else if let Some(path) = data_file {
+        Some(
+            std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read body from file: {}", path.display()))?,
+        )
+    } else {
+        None
+    };
+
+    // Parse and validate JSON
+    if let Some(body_str) = body_str {
+        let value: Value = serde_json::from_str(&body_str)
+            .with_context(|| "Invalid JSON in request body")?;
+        Ok(Some(value))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Get authentication token from auth client
+async fn get_auth_token(auth_client: &AuthClient) -> Result<String> {
+    // Try 3-legged token first, fall back to 2-legged
+    match auth_client.get_3leg_token().await {
+        Ok(token) => Ok(token),
+        Err(_) => {
+            // Try 2-legged token
+            auth_client.get_token().await.with_context(|| {
+                "Not authenticated. Run 'raps auth login' first.\n\
+                 Hint: Use 'raps auth login' for 3-legged auth or configure client credentials for 2-legged auth."
+            })
+        }
+    }
+}
+
+/// Execute HTTP request with authentication
+async fn execute_request(
+    client: &Client,
+    method: HttpMethod,
+    url: &str,
+    token: &str,
+    custom_headers: &[(String, String)],
+    body: Option<&Value>,
+) -> Result<Response> {
+    logging::log_verbose(&format!("{} {}", method.as_reqwest_method(), url));
+
+    let mut request = client.request(method.as_reqwest_method(), url);
+
+    // Add authorization header
+    request = request.header(AUTHORIZATION, format!("Bearer {}", token));
+
+    // Add custom headers (but prevent overriding Authorization)
+    for (key, value) in custom_headers {
+        if key.to_lowercase() == "authorization" {
+            logging::log_verbose("Warning: Cannot override Authorization header, ignoring");
+            continue;
+        }
+        if let (Ok(name), Ok(val)) = (
+            HeaderName::from_str(key),
+            HeaderValue::from_str(value),
+        ) {
+            request = request.header(name, val);
+        }
+    }
+
+    // Add body if present
+    if let Some(body) = body {
+        request = request
+            .header(CONTENT_TYPE, "application/json")
+            .json(body);
+    }
+
+    let response = request
+        .send()
+        .await
+        .context("Failed to send request")?;
+
+    Ok(response)
+}
+
+/// Handle HTTP response and format output
+async fn handle_response(
+    response: Response,
+    output_format: OutputFormat,
+    output_file: Option<PathBuf>,
+    verbose: bool,
+) -> Result<()> {
+    let status = response.status();
+    let status_code = status.as_u16();
+
+    // Collect headers for verbose output
+    let headers: Vec<(String, String)> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    // Print verbose output if requested
+    if verbose {
+        println!("{}", format!("HTTP/1.1 {} {}", status_code, status.canonical_reason().unwrap_or("")).cyan());
+        for (key, value) in &headers {
+            println!("{}: {}", key.dimmed(), value);
+        }
+        println!();
+    }
+
+    // Handle response based on content type and status
+    if content_type.contains("application/json") {
+        let body_text = response.text().await.context("Failed to read response body")?;
+
+        // Try to parse as JSON
+        let json: Result<Value, _> = serde_json::from_str(&body_text);
+
+        match json {
+            Ok(value) => {
+                if status.is_success() {
+                    // Save to file if requested
+                    if let Some(path) = output_file {
+                        std::fs::write(&path, serde_json::to_string_pretty(&value)?)?;
+                        println!("{} {}", "Saved to:".green(), path.display());
+                    } else {
+                        // Output using configured format
+                        output_format.write(&value)?;
+                    }
+                    Ok(())
+                } else {
+                    // Error response
+                    let error = ApiError {
+                        status_code,
+                        error_type: categorize_error(status_code),
+                        message: extract_error_message(&value, status),
+                        details: Some(value),
+                    };
+                    output_format.write(&error)?;
+                    std::process::exit(map_exit_code(status_code));
+                }
+            }
+            Err(_) => {
+                // JSON parse failed, treat as text
+                if status.is_success() {
+                    if let Some(path) = output_file {
+                        std::fs::write(&path, &body_text)?;
+                        println!("{} {}", "Saved to:".green(), path.display());
+                    } else {
+                        println!("{}", body_text);
+                    }
+                    Ok(())
+                } else {
+                    eprintln!("{} {} - {}", "Error:".red(), status_code, body_text);
+                    std::process::exit(map_exit_code(status_code));
+                }
+            }
+        }
+    } else if content_type.starts_with("text/") || content_type.contains("xml") {
+        // Text response
+        let body_text = response.text().await.context("Failed to read response body")?;
+
+        if status.is_success() {
+            if let Some(path) = output_file {
+                std::fs::write(&path, &body_text)?;
+                println!("{} {}", "Saved to:".green(), path.display());
+            } else {
+                println!("{}", body_text);
+            }
+            Ok(())
+        } else {
+            eprintln!("{} {} - {}", "Error:".red(), status_code, body_text);
+            std::process::exit(map_exit_code(status_code));
+        }
+    } else {
+        // Binary response
+        let bytes = response.bytes().await.context("Failed to read response body")?;
+
+        if status.is_success() {
+            if let Some(path) = output_file {
+                std::fs::write(&path, &bytes)?;
+                println!("{} {} ({} bytes)", "Saved to:".green(), path.display(), bytes.len());
+                Ok(())
+            } else {
+                bail!(
+                    "Binary response received. Use --output to save to a file.\n\
+                     Content-Type: {}, Size: {} bytes",
+                    content_type,
+                    bytes.len()
+                );
+            }
+        } else {
+            eprintln!("{} {} - Binary error response ({} bytes)", "Error:".red(), status_code, bytes.len());
+            std::process::exit(map_exit_code(status_code));
+        }
+    }
+}
+
+/// Categorize error based on status code
+fn categorize_error(status_code: u16) -> String {
+    match status_code {
+        401 | 403 => "authentication".to_string(),
+        400 | 422 => "validation".to_string(),
+        404 => "not_found".to_string(),
+        429 => "rate_limited".to_string(),
+        500..=599 => "server_error".to_string(),
+        _ => "error".to_string(),
+    }
+}
+
+/// Extract error message from JSON response
+fn extract_error_message(value: &Value, status: StatusCode) -> String {
+    // Try common error message fields
+    if let Some(msg) = value.get("message").and_then(|v| v.as_str()) {
+        return msg.to_string();
+    }
+    if let Some(msg) = value.get("error").and_then(|v| v.as_str()) {
+        return msg.to_string();
+    }
+    if let Some(msg) = value.get("reason").and_then(|v| v.as_str()) {
+        return msg.to_string();
+    }
+    if let Some(msg) = value.get("developerMessage").and_then(|v| v.as_str()) {
+        return msg.to_string();
+    }
+
+    // Fallback to status text
+    status.canonical_reason().unwrap_or("Request failed").to_string()
+}
+
+/// Map HTTP status code to exit code
+fn map_exit_code(status_code: u16) -> i32 {
+    match status_code {
+        200..=299 => 0,  // Success
+        401 | 403 => 10, // Authentication error
+        400 | 422 => 2,  // Validation/client error
+        _ => 1,          // General error
+    }
+}

--- a/raps-cli/src/commands/mod.rs
+++ b/raps-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod acc;
 pub mod admin;
+pub mod api;
 pub mod auth;
 pub mod bucket;
 pub mod config;
@@ -23,11 +24,13 @@ pub mod plugin;
 pub mod project;
 pub mod reality;
 pub mod rfi;
+pub mod template;
 pub mod translate;
 pub mod webhook;
 
 pub use acc::AccCommands;
 pub use admin::AdminCommands;
+pub use api::ApiCommands;
 pub use auth::AuthCommands;
 pub use bucket::BucketCommands;
 pub use config::ConfigCommands;
@@ -44,5 +47,6 @@ pub use plugin::PluginCommands;
 pub use project::ProjectCommands;
 pub use reality::RealityCommands;
 pub use rfi::RfiCommands;
+pub use template::TemplateCommands;
 pub use translate::TranslateCommands;
 pub use webhook::WebhookCommands;

--- a/raps-cli/src/mcp/tools.rs
+++ b/raps-cli/src/mcp/tools.rs
@@ -9,7 +9,7 @@
 // Tool definitions are in server.rs.
 // This module is reserved for additional utilities and extended tool implementations.
 
-/// Available MCP tools in the RAPS server (v4.4 - 50 tools)
+/// Available MCP tools in the RAPS server (v4.5 - 56 tools)
 #[allow(dead_code)]
 pub const TOOLS: &[&str] = &[
     // Authentication
@@ -56,6 +56,12 @@ pub const TOOLS: &[&str] = &[
     "project_create",
     "project_user_add",
     "project_users_import",
+    // Template Management (v4.5)
+    "template_list",
+    "template_info",
+    "template_create",
+    "template_update",
+    "template_archive",
     // Folder/Item Management
     "folder_list",
     "folder_create",
@@ -86,4 +92,6 @@ pub const TOOLS: &[&str] = &[
     "acc_checklists_list",
     "checklist_create",
     "checklist_update",
+    // Custom API (v4.5)
+    "api_request",
 ];

--- a/raps-cli/tests/api_tests.rs
+++ b/raps-cli/tests/api_tests.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 Dmytro Yemelianov
+
+//! Integration tests for the custom API command
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// Helper to create a raps command
+fn raps() -> Command {
+    Command::cargo_bin("raps").unwrap()
+}
+
+#[test]
+fn test_api_help() {
+    raps()
+        .arg("api")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Execute custom API calls"));
+}
+
+#[test]
+fn test_api_get_help() {
+    raps()
+        .args(["api", "get", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Execute HTTP GET request"))
+        .stdout(predicate::str::contains("--query"))
+        .stdout(predicate::str::contains("--header"))
+        .stdout(predicate::str::contains("--output"))
+        .stdout(predicate::str::contains("--verbose"));
+}
+
+#[test]
+fn test_api_post_help() {
+    raps()
+        .args(["api", "post", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Execute HTTP POST request"))
+        .stdout(predicate::str::contains("--data"))
+        .stdout(predicate::str::contains("--data-file"));
+}
+
+#[test]
+fn test_api_put_help() {
+    raps()
+        .args(["api", "put", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Execute HTTP PUT request"));
+}
+
+#[test]
+fn test_api_patch_help() {
+    raps()
+        .args(["api", "patch", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Execute HTTP PATCH request"));
+}
+
+#[test]
+fn test_api_delete_help() {
+    raps()
+        .args(["api", "delete", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Execute HTTP DELETE request"));
+}
+
+#[test]
+fn test_api_get_missing_endpoint() {
+    raps()
+        .args(["api", "get"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_api_post_data_file_conflict() {
+    // --data and --data-file should conflict
+    raps()
+        .args(["api", "post", "/test", "--data", "{}", "--data-file", "test.json"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_api_get_invalid_query_format() {
+    // Query params should be KEY=VALUE format
+    raps()
+        .args(["api", "get", "/test", "--query", "invalid"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid format"));
+}
+
+#[test]
+fn test_api_get_invalid_header_format() {
+    // Headers should be KEY:VALUE format
+    raps()
+        .args(["api", "get", "/test", "--header", "invalid"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid header format"));
+}

--- a/specs/007-custom-api-calls/checklists/requirements.md
+++ b/specs/007-custom-api-calls/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Custom API Calls
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- 17 functional requirements defined covering CLI and MCP interfaces
+- 4 user stories prioritized (P1-P3) with acceptance scenarios
+- 5 edge cases documented with expected behavior

--- a/specs/007-custom-api-calls/contracts/cli-interface.md
+++ b/specs/007-custom-api-calls/contracts/cli-interface.md
@@ -1,0 +1,274 @@
+# CLI Interface Contract: Custom API Calls
+
+**Feature**: 007-custom-api-calls
+**Date**: 2026-01-22
+
+## Command Structure
+
+```text
+raps api <METHOD> <ENDPOINT> [OPTIONS]
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `get` | Execute HTTP GET request |
+| `post` | Execute HTTP POST request |
+| `put` | Execute HTTP PUT request |
+| `patch` | Execute HTTP PATCH request |
+| `delete` | Execute HTTP DELETE request |
+
+---
+
+## Command: `raps api get`
+
+Execute a GET request to an APS API endpoint.
+
+### Synopsis
+
+```bash
+raps api get <ENDPOINT> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ENDPOINT` | Yes | API endpoint path (e.g., `/oss/v2/buckets`) |
+
+### Options
+
+| Option | Short | Type | Description |
+|--------|-------|------|-------------|
+| `--query` | `-q` | KEY=VALUE | Query parameter (repeatable) |
+| `--header` | `-H` | KEY:VALUE | Custom header (repeatable) |
+| `--output` | `-o` | PATH | Save response to file |
+| `--verbose` | `-v` | flag | Show response headers and status |
+
+### Examples
+
+```bash
+# Get current user profile
+raps api get /userprofile/v1/users/@me
+
+# List buckets with query parameter
+raps api get /oss/v2/buckets --query limit=10 --query region=US
+
+# Get with custom header and verbose output
+raps api get /oss/v2/buckets -H "x-ads-region:US" --verbose
+
+# Save response to file
+raps api get /oss/v2/buckets -o buckets.json
+```
+
+---
+
+## Command: `raps api post`
+
+Execute a POST request to create a resource.
+
+### Synopsis
+
+```bash
+raps api post <ENDPOINT> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ENDPOINT` | Yes | API endpoint path |
+
+### Options
+
+| Option | Short | Type | Description |
+|--------|-------|------|-------------|
+| `--data` | `-d` | JSON | Inline JSON request body |
+| `--data-file` | `-f` | PATH | Read request body from file |
+| `--query` | `-q` | KEY=VALUE | Query parameter (repeatable) |
+| `--header` | `-H` | KEY:VALUE | Custom header (repeatable) |
+| `--output` | `-o` | PATH | Save response to file |
+| `--verbose` | `-v` | flag | Show response headers and status |
+
+### Examples
+
+```bash
+# Create bucket with inline JSON
+raps api post /oss/v2/buckets -d '{"bucketKey":"my-bucket","policyKey":"transient"}'
+
+# Create from file
+raps api post /oss/v2/buckets --data-file bucket.json
+
+# POST with query params
+raps api post /endpoint --query param=value -d '{}'
+```
+
+---
+
+## Command: `raps api put`
+
+Execute a PUT request to replace a resource.
+
+### Synopsis
+
+```bash
+raps api put <ENDPOINT> [OPTIONS]
+```
+
+### Options
+
+Same as `raps api post`.
+
+### Examples
+
+```bash
+# Update resource
+raps api put /resource/123 -d '{"name":"updated"}'
+```
+
+---
+
+## Command: `raps api patch`
+
+Execute a PATCH request to update a resource.
+
+### Synopsis
+
+```bash
+raps api patch <ENDPOINT> [OPTIONS]
+```
+
+### Options
+
+Same as `raps api post`.
+
+### Examples
+
+```bash
+# Partial update
+raps api patch /resource/123 -d '{"status":"active"}'
+```
+
+---
+
+## Command: `raps api delete`
+
+Execute a DELETE request to remove a resource.
+
+### Synopsis
+
+```bash
+raps api delete <ENDPOINT> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ENDPOINT` | Yes | API endpoint path |
+
+### Options
+
+| Option | Short | Type | Description |
+|--------|-------|------|-------------|
+| `--query` | `-q` | KEY=VALUE | Query parameter (repeatable) |
+| `--header` | `-H` | KEY:VALUE | Custom header (repeatable) |
+| `--verbose` | `-v` | flag | Show response headers and status |
+
+### Examples
+
+```bash
+# Delete bucket
+raps api delete /oss/v2/buckets/my-bucket
+
+# Delete with query param
+raps api delete /resource/123 --query force=true
+```
+
+---
+
+## Global Options
+
+These options from the main `raps` command apply to all `api` subcommands:
+
+| Option | Description |
+|--------|-------------|
+| `--output-format` | Output format: json, yaml, table, csv, plain |
+| `--no-color` | Disable colored output |
+| `--quiet` | Suppress non-essential output |
+| `--debug` | Enable debug logging |
+| `--timeout` | Request timeout in seconds |
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success (2xx response) |
+| 1 | General error (4xx/5xx response, network error) |
+| 2 | Command-line error (invalid arguments, validation failure) |
+| 10 | Authentication error (401/403 or no token) |
+
+---
+
+## Output Formats
+
+### Default (JSON)
+
+```json
+{
+  "items": [...],
+  "next": "..."
+}
+```
+
+### With `--verbose`
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Request-Id: abc123
+
+{
+  "items": [...],
+  "next": "..."
+}
+```
+
+### Error Response
+
+```json
+{
+  "status": 404,
+  "error": "not_found",
+  "message": "Bucket 'xyz' not found",
+  "details": { ... }
+}
+```
+
+---
+
+## Validation Rules
+
+1. **Endpoint must be relative path or allowed domain**
+   - Valid: `/oss/v2/buckets`, `/userprofile/v1/users/@me`
+   - Invalid: `https://evil.com/steal-token`
+
+2. **Body options are mutually exclusive**
+   - `--data` and `--data-file` cannot be used together
+
+3. **Body only allowed for POST, PUT, PATCH**
+   - `raps api get /endpoint --data '{}'` → Error
+
+4. **JSON body must be valid JSON**
+   - Invalid JSON in `--data` or `--data-file` → Error with parse message
+
+5. **Header format must be KEY:VALUE**
+   - `--header "Content-Type: application/xml"` → Valid
+   - `--header "InvalidHeader"` → Error
+
+6. **Query format must be KEY=VALUE**
+   - `--query limit=10` → Valid
+   - `--query invalidquery` → Error

--- a/specs/007-custom-api-calls/contracts/mcp-tool.md
+++ b/specs/007-custom-api-calls/contracts/mcp-tool.md
@@ -1,0 +1,238 @@
+# MCP Tool Contract: api_request
+
+**Feature**: 007-custom-api-calls
+**Date**: 2026-01-22
+
+## Tool Definition
+
+### Name
+
+`api_request`
+
+### Description
+
+Execute a custom HTTP request to any APS API endpoint using the current authentication. Supports all HTTP methods (GET, POST, PUT, PATCH, DELETE) with optional body, headers, and query parameters.
+
+---
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "method": {
+      "type": "string",
+      "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+      "description": "HTTP method to use"
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "API endpoint path relative to APS base URL (e.g., /oss/v2/buckets)"
+    },
+    "body": {
+      "type": "object",
+      "description": "Request body as JSON object. Only valid for POST, PUT, PATCH methods."
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Custom headers to include in the request. Authorization header is set automatically."
+    },
+    "query": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Query parameters to append to the endpoint URL."
+    }
+  },
+  "required": ["method", "endpoint"]
+}
+```
+
+---
+
+## Output Format
+
+### Success Response (2xx)
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "data": { ... }
+}
+```
+
+The `data` field contains the parsed JSON response from the API.
+
+### Error Response (4xx/5xx)
+
+```json
+{
+  "success": false,
+  "status": 404,
+  "error": "not_found",
+  "message": "Bucket 'xyz' not found",
+  "details": { ... }
+}
+```
+
+### Validation Error
+
+```json
+{
+  "success": false,
+  "error": "validation_error",
+  "message": "Body is not allowed for GET requests"
+}
+```
+
+---
+
+## Examples
+
+### GET Request
+
+**Input:**
+```json
+{
+  "method": "GET",
+  "endpoint": "/oss/v2/buckets",
+  "query": {
+    "limit": "10",
+    "region": "US"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "status": 200,
+  "data": {
+    "items": [
+      {
+        "bucketKey": "my-bucket",
+        "policyKey": "transient"
+      }
+    ]
+  }
+}
+```
+
+### POST Request with Body
+
+**Input:**
+```json
+{
+  "method": "POST",
+  "endpoint": "/oss/v2/buckets",
+  "body": {
+    "bucketKey": "new-bucket",
+    "policyKey": "persistent"
+  },
+  "headers": {
+    "x-ads-region": "US"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "status": 201,
+  "data": {
+    "bucketKey": "new-bucket",
+    "bucketOwner": "...",
+    "createdDate": 1706000000000
+  }
+}
+```
+
+### DELETE Request
+
+**Input:**
+```json
+{
+  "method": "DELETE",
+  "endpoint": "/oss/v2/buckets/old-bucket"
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "status": 200,
+  "data": {}
+}
+```
+
+### Error Example
+
+**Input:**
+```json
+{
+  "method": "GET",
+  "endpoint": "/oss/v2/buckets/nonexistent"
+}
+```
+
+**Output:**
+```json
+{
+  "success": false,
+  "status": 404,
+  "error": "not_found",
+  "message": "Bucket 'nonexistent' does not exist"
+}
+```
+
+---
+
+## Validation Rules
+
+1. **Method is required and must be valid enum value**
+   - Invalid method → `"error": "Invalid method. Must be GET, POST, PUT, PATCH, or DELETE"`
+
+2. **Endpoint is required and must be valid APS path**
+   - Empty endpoint → `"error": "Endpoint is required"`
+   - External URL → `"error": "Only APS API endpoints are allowed"`
+
+3. **Body only allowed for POST, PUT, PATCH**
+   - Body with GET/DELETE → `"error": "Body is not allowed for GET/DELETE requests"`
+
+4. **Authentication required**
+   - No valid token → `"error": "Not authenticated. Run 'raps auth login' first."`
+
+---
+
+## Security Constraints
+
+- Requests are restricted to APS domains only
+- Authorization header is set automatically from stored token
+- User-provided Authorization header is ignored
+- No credential or token data is included in tool responses
+
+---
+
+## Integration with Existing Tools
+
+The `api_request` tool complements existing RAPS MCP tools:
+
+| Use Case | Recommended Tool |
+|----------|-----------------|
+| List buckets | `bucket_list` (typed, documented) |
+| Custom bucket query | `api_request` with GET /oss/v2/buckets |
+| Unsupported endpoint | `api_request` (only option) |
+
+**When to use `api_request`:**
+- Endpoint not covered by existing typed tools
+- Need specific query parameters not exposed by typed tools
+- Exploring new APS API features before RAPS adds support

--- a/specs/007-custom-api-calls/data-model.md
+++ b/specs/007-custom-api-calls/data-model.md
@@ -1,0 +1,217 @@
+# Data Model: Custom API Calls
+
+**Feature**: 007-custom-api-calls
+**Date**: 2026-01-22
+
+## Overview
+
+This feature introduces data structures for representing custom API requests and responses. The model is intentionally simple since the feature acts as a pass-through to arbitrary APS endpoints.
+
+---
+
+## Entities
+
+### 1. ApiRequest
+
+Represents a custom API call to be executed.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| method | HttpMethod | Yes | HTTP method (GET, POST, PUT, PATCH, DELETE) |
+| endpoint | String | Yes | API endpoint path (e.g., `/oss/v2/buckets`) |
+| headers | Map<String, String> | No | Custom headers to include |
+| query_params | Vec<(String, String)> | No | Query parameters (key-value pairs) |
+| body | Option<Value> | No | Request body (JSON value) |
+
+**Validation Rules**:
+- `endpoint` must start with `/` (relative path) or be a full URL to an allowed domain
+- `body` is only valid for POST, PUT, PATCH methods
+- `headers` cannot override Authorization header (set automatically)
+
+**Derived Fields**:
+- `full_url`: Computed from base URL + endpoint + query params
+
+---
+
+### 2. HttpMethod
+
+Enumeration of supported HTTP methods.
+
+| Value | Description |
+|-------|-------------|
+| GET | Retrieve resource(s) |
+| POST | Create resource |
+| PUT | Replace resource |
+| PATCH | Update resource |
+| DELETE | Remove resource |
+
+---
+
+### 3. ApiResponse
+
+Represents the response from a custom API call.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| status_code | u16 | Yes | HTTP status code |
+| headers | Map<String, String> | Yes | Response headers |
+| content_type | String | Yes | Content-Type header value |
+| body | ResponseBody | Yes | Response body (see below) |
+
+---
+
+### 4. ResponseBody
+
+Represents the response body in different formats.
+
+| Variant | Payload | Description |
+|---------|---------|-------------|
+| Json | serde_json::Value | Parsed JSON response |
+| Text | String | Text response (XML, HTML, plain text) |
+| Binary | Vec<u8> | Binary response (images, files) |
+
+**Content-Type Mapping**:
+- `application/json` → Json
+- `text/*`, `application/xml` → Text
+- Everything else → Binary
+
+---
+
+### 5. ApiError
+
+Error response structure for failed requests.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| status_code | u16 | Yes | HTTP status code |
+| error_type | String | Yes | Error category |
+| message | String | Yes | Human-readable error message |
+| details | Option<Value> | No | Additional error details from API |
+
+**Error Categories**:
+- `authentication`: 401/403 responses
+- `validation`: 400/422 responses (bad request, invalid input)
+- `not_found`: 404 responses
+- `rate_limited`: 429 responses
+- `server_error`: 5xx responses
+- `network`: Connection failures, timeouts
+
+---
+
+## Relationships
+
+```text
+┌─────────────┐
+│  ApiRequest │
+├─────────────┤         ┌──────────────┐
+│ method      │────────>│  HttpMethod  │
+│ endpoint    │         └──────────────┘
+│ headers     │
+│ query_params│         ┌──────────────┐
+│ body        │────────>│    Value     │ (JSON)
+└─────────────┘         └──────────────┘
+       │
+       │ executes
+       ▼
+┌─────────────┐
+│ ApiResponse │
+├─────────────┤         ┌──────────────┐
+│ status_code │         │ ResponseBody │
+│ headers     │────────>├──────────────┤
+│ content_type│         │ Json(Value)  │
+│ body        │         │ Text(String) │
+└─────────────┘         │ Binary(bytes)│
+       │                └──────────────┘
+       │ on error
+       ▼
+┌─────────────┐
+│  ApiError   │
+├─────────────┤
+│ status_code │
+│ error_type  │
+│ message     │
+│ details     │
+└─────────────┘
+```
+
+---
+
+## State Transitions
+
+This feature is stateless. Each request is independent with no persistent state between calls.
+
+---
+
+## CLI Output Structures
+
+### SuccessOutput (for 2xx responses)
+
+Used when formatting successful API responses for CLI output.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | u16 | HTTP status code |
+| data | Value | Response body (JSON) |
+
+### ErrorOutput (for 4xx/5xx responses)
+
+Used when formatting error responses for CLI output.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | u16 | HTTP status code |
+| error | String | Error category |
+| message | String | Error message |
+| details | Option<Value> | Additional details |
+
+---
+
+## MCP Tool Schema
+
+### api_request Input
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "method": {
+      "type": "string",
+      "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+      "description": "HTTP method"
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "API endpoint path (e.g., /oss/v2/buckets)"
+    },
+    "body": {
+      "type": "object",
+      "description": "Request body for POST/PUT/PATCH"
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Custom headers"
+    },
+    "query": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Query parameters"
+    }
+  },
+  "required": ["method", "endpoint"]
+}
+```
+
+### api_request Output
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": { "type": "integer" },
+    "success": { "type": "boolean" },
+    "data": { "type": "object" },
+    "error": { "type": "string" }
+  }
+}
+```

--- a/specs/007-custom-api-calls/plan.md
+++ b/specs/007-custom-api-calls/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Custom API Calls
+
+**Branch**: `007-custom-api-calls` | **Date**: 2026-01-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/007-custom-api-calls/spec.md`
+
+## Summary
+
+Add a custom API call capability to RAPS that allows users to invoke any APS API endpoint directly using the currently authenticated session. This feature will be exposed via CLI subcommands (`raps api get`, `raps api post`, etc.) and an MCP tool (`api_request`), supporting all HTTP methods, query parameters, request bodies, custom headers, and multiple output formats. Requests are restricted to APS domains only for security.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88, Edition 2024
+**Primary Dependencies**: clap 4.5 (CLI), reqwest 0.11 (HTTP), tokio 1.49 (async), serde/serde_json (serialization), rmcp 0.12 (MCP server)
+**Storage**: N/A (uses existing keyring-based token storage from raps-kernel)
+**Testing**: cargo test, assert_cmd 2.0 (CLI integration), predicates 3.1, nextest
+**Target Platform**: Cross-platform (Linux, macOS, Windows)
+**Project Type**: Single (workspace crate addition to existing CLI)
+**Performance Goals**: <5s for typical API responses (per SC-001); MCP within 10% of CLI overhead (per SC-006)
+**Constraints**: APS domains only (developer.api.autodesk.com, api.userprofile.autodesk.com, and related Autodesk API hosts)
+**Scale/Scope**: Extends existing CLI with 1 new command group (5 subcommands) and 1 new MCP tool
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution file contains placeholder content (not project-specific rules). Applying standard Rust CLI best practices:
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Follows existing patterns | ✅ Pass | Uses same clap/subcommand architecture as existing commands |
+| Reuses existing components | ✅ Pass | Leverages raps-kernel auth, HTTP client, config; raps-cli output formatting |
+| Test coverage | ✅ Pass | Will include unit tests for validation, integration tests for CLI |
+| Error handling | ✅ Pass | Uses existing anyhow/thiserror patterns, exit codes |
+| Security | ✅ Pass | Domain restriction prevents credential leakage to external URLs |
+
+No constitution violations. Proceeding with Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-custom-api-calls/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (CLI interface contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+raps-cli/
+├── src/
+│   ├── commands/
+│   │   ├── mod.rs           # Add api module export
+│   │   └── api.rs           # NEW: Custom API command implementation
+│   ├── mcp/
+│   │   ├── server.rs        # Add api_request tool dispatch
+│   │   └── tools.rs         # Add api_request to TOOLS constant
+│   └── main.rs              # Add Api variant to Commands enum
+└── tests/
+    └── api_tests.rs         # NEW: Integration tests for api command
+
+raps-kernel/
+└── src/
+    └── http.rs              # Add domain validation helper (allowed_domains)
+```
+
+**Structure Decision**: Extends existing single-workspace CLI structure. New command module `api.rs` follows the established pattern of other commands (bucket.rs, object.rs, etc.). Domain validation logic placed in raps-kernel for reuse by both CLI and MCP.
+
+## Complexity Tracking
+
+No constitution violations requiring justification. Implementation follows existing patterns with minimal added complexity:
+
+- Single new command module (not a new crate)
+- Reuses existing HTTP client, auth, and output formatting
+- Domain validation is a simple allowlist check

--- a/specs/007-custom-api-calls/quickstart.md
+++ b/specs/007-custom-api-calls/quickstart.md
@@ -1,0 +1,223 @@
+# Quickstart: Custom API Calls
+
+**Feature**: 007-custom-api-calls
+
+This guide helps you get started with the custom API calls feature in RAPS.
+
+---
+
+## Prerequisites
+
+1. **RAPS installed** - [Installation guide](https://rapscli.xyz/install)
+2. **Authenticated** - Run `raps auth login` to authenticate with your Autodesk account
+
+---
+
+## CLI Usage
+
+### Basic GET Request
+
+Retrieve your user profile:
+
+```bash
+raps api get /userprofile/v1/users/@me
+```
+
+### GET with Query Parameters
+
+List buckets with pagination:
+
+```bash
+raps api get /oss/v2/buckets --query limit=10 --query startAt=0
+```
+
+### POST with JSON Body
+
+Create a new bucket:
+
+```bash
+raps api post /oss/v2/buckets \
+  --data '{"bucketKey":"my-new-bucket","policyKey":"transient"}'
+```
+
+### POST from File
+
+Create a resource using a JSON file:
+
+```bash
+# Create payload file
+echo '{"bucketKey":"my-bucket","policyKey":"persistent"}' > bucket.json
+
+# Execute request
+raps api post /oss/v2/buckets --data-file bucket.json
+```
+
+### Custom Headers
+
+Add custom headers to your request:
+
+```bash
+raps api get /oss/v2/buckets \
+  --header "x-ads-region:US" \
+  --header "Accept:application/json"
+```
+
+### Save Response to File
+
+Save the response body to a file:
+
+```bash
+raps api get /oss/v2/buckets -o buckets.json
+```
+
+### Verbose Output
+
+See response headers and status:
+
+```bash
+raps api get /oss/v2/buckets --verbose
+```
+
+Output:
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+x-request-id: abc123
+
+{
+  "items": [...]
+}
+```
+
+---
+
+## MCP Tool Usage
+
+### Tool: api_request
+
+The `api_request` MCP tool allows AI assistants to make custom API calls.
+
+#### Example: GET Request
+
+```json
+{
+  "method": "GET",
+  "endpoint": "/oss/v2/buckets",
+  "query": {
+    "limit": "5"
+  }
+}
+```
+
+#### Example: POST Request
+
+```json
+{
+  "method": "POST",
+  "endpoint": "/oss/v2/buckets",
+  "body": {
+    "bucketKey": "ai-created-bucket",
+    "policyKey": "transient"
+  }
+}
+```
+
+---
+
+## Output Formats
+
+Use the global `--output-format` flag to change output:
+
+```bash
+# JSON (default)
+raps api get /oss/v2/buckets
+
+# YAML
+raps api get /oss/v2/buckets --output-format yaml
+
+# Table
+raps api get /oss/v2/buckets --output-format table
+
+# CSV
+raps api get /oss/v2/buckets --output-format csv
+```
+
+---
+
+## Common Use Cases
+
+### Explore Undocumented Endpoints
+
+Test new or beta APS endpoints:
+
+```bash
+raps api get /some/beta/endpoint/v1
+```
+
+### Debug API Responses
+
+Use verbose mode to troubleshoot:
+
+```bash
+raps api get /oss/v2/buckets/my-bucket --verbose
+```
+
+### Script Integration
+
+Use in shell scripts with exit code checking:
+
+```bash
+#!/bin/bash
+if raps api get /oss/v2/buckets/my-bucket > /dev/null 2>&1; then
+    echo "Bucket exists"
+else
+    echo "Bucket not found"
+fi
+```
+
+### Chain with jq
+
+Process JSON responses:
+
+```bash
+raps api get /oss/v2/buckets | jq '.items[].bucketKey'
+```
+
+---
+
+## Error Handling
+
+### Authentication Error
+
+```bash
+$ raps api get /oss/v2/buckets
+Error: Not authenticated. Run 'raps auth login' first.
+```
+
+**Solution:** Run `raps auth login` to authenticate.
+
+### Invalid Endpoint
+
+```bash
+$ raps api get https://evil.com/endpoint
+Error: Only APS API endpoints are allowed. Use a path like /oss/v2/buckets
+```
+
+**Solution:** Use relative paths to APS APIs.
+
+### Invalid JSON
+
+```bash
+$ raps api post /endpoint --data '{invalid}'
+Error: Invalid JSON: expected value at line 1 column 2
+```
+
+**Solution:** Ensure valid JSON syntax in `--data` or `--data-file`.
+
+---
+
+## Next Steps
+
+- See [CLI Interface Contract](./contracts/cli-interface.md) for full command reference
+- See [MCP Tool Contract](./contracts/mcp-tool.md) for MCP integration details
+- See [Data Model](./data-model.md) for entity definitions

--- a/specs/007-custom-api-calls/research.md
+++ b/specs/007-custom-api-calls/research.md
@@ -1,0 +1,228 @@
+# Research: Custom API Calls
+
+**Feature**: 007-custom-api-calls
+**Date**: 2026-01-22
+
+## Research Summary
+
+This document captures design decisions and research findings for implementing custom API calls in RAPS.
+
+---
+
+## 1. Domain Validation Strategy
+
+**Decision**: Allowlist-based URL validation with compile-time domain constants
+
+**Rationale**:
+- Security requirement FR-005 mandates restricting requests to APS domains only
+- Prevents credential leakage to external URLs (SSRF-like attack vector)
+- Simple allowlist is sufficient given the known set of Autodesk API hosts
+
+**Alternatives Considered**:
+| Alternative | Reason Rejected |
+|------------|-----------------|
+| Regex pattern matching | Overly complex, prone to bypass via subdomain tricks |
+| Denylist (block known bad domains) | Insecure - can't anticipate all malicious domains |
+| No validation (trust user) | Violates security requirement, enables credential leakage |
+
+**Implementation**:
+```rust
+const ALLOWED_DOMAINS: &[&str] = &[
+    "developer.api.autodesk.com",
+    "api.userprofile.autodesk.com",
+    "acc.autodesk.com",
+    "developer.autodesk.com",
+];
+
+fn is_allowed_url(url: &str) -> bool {
+    // Parse URL, extract host, check against allowlist
+}
+```
+
+---
+
+## 2. CLI Subcommand Architecture
+
+**Decision**: Method-based subcommands (`raps api get`, `raps api post`, etc.)
+
+**Rationale**:
+- Matches clarification decision from spec (Session 2026-01-22)
+- Follows established pattern in RAPS (e.g., `bucket create`, `object delete`)
+- More discoverable via `raps api --help`
+- Enables method-specific argument validation (e.g., GET doesn't need `--data`)
+
+**Alternatives Considered**:
+| Alternative | Reason Rejected |
+|------------|-----------------|
+| Single command with `--method` flag | Less ergonomic, requires flag for every call |
+| HTTP verb aliases (`raps get`, `raps post`) | Pollutes top-level namespace |
+
+**Implementation**: Clap enum with 5 variants:
+```rust
+#[derive(Subcommand)]
+pub enum ApiCommands {
+    Get { endpoint: String, ... },
+    Post { endpoint: String, ... },
+    Put { endpoint: String, ... },
+    Patch { endpoint: String, ... },
+    Delete { endpoint: String, ... },
+}
+```
+
+---
+
+## 3. Request Body Handling
+
+**Decision**: Support both inline JSON (`--data`) and file input (`--data-file`) with mutual exclusion
+
+**Rationale**:
+- Inline JSON is convenient for small payloads and scripting
+- File input handles large/complex payloads and avoids shell escaping issues
+- Mutual exclusion prevents ambiguity (which takes precedence?)
+- Matches curl pattern (`-d` vs `@file`)
+
+**Alternatives Considered**:
+| Alternative | Reason Rejected |
+|------------|-----------------|
+| Only inline JSON | Large payloads become unwieldy, shell escaping problems |
+| Only file input | Inconvenient for simple requests, requires temp files |
+| Allow both (merge) | Complex semantics, potential for confusion |
+| Stdin support | Adds complexity; file input covers same use case |
+
+**Implementation**:
+```rust
+#[arg(short, long, conflicts_with = "data_file")]
+data: Option<String>,
+
+#[arg(short = 'f', long, conflicts_with = "data")]
+data_file: Option<PathBuf>,
+```
+
+---
+
+## 4. Output Handling
+
+**Decision**: Reuse existing OutputFormat system with content-type detection
+
+**Rationale**:
+- Maintains consistency with other RAPS commands
+- JSON responses format naturally with existing table/yaml/csv converters
+- Non-JSON responses need special handling (text pass-through, binary to file)
+
+**Alternatives Considered**:
+| Alternative | Reason Rejected |
+|------------|-----------------|
+| Always output raw response | Loses formatting benefits, inconsistent with other commands |
+| Force JSON-only responses | Some APS endpoints return XML or binary data |
+
+**Implementation**:
+1. Check response Content-Type header
+2. If JSON: deserialize and pass through OutputFormat formatter
+3. If text (XML, HTML, plain): display as-is
+4. If binary: require `--output` flag, write to file
+
+---
+
+## 5. MCP Tool Design
+
+**Decision**: Single `api_request` tool with method parameter
+
+**Rationale**:
+- MCP tools are invoked programmatically, not typed by humans
+- Single tool with method enum is cleaner than 5 separate tools
+- Easier for AI assistants to discover (one tool to learn)
+- JSON schema clearly defines available methods
+
+**Alternatives Considered**:
+| Alternative | Reason Rejected |
+|------------|-----------------|
+| Separate tools (`api_get`, `api_post`, etc.) | Clutters tool list, redundant parameter definitions |
+| Match CLI structure exactly | MCP ergonomics differ from CLI; single tool is idiomatic |
+
+**Implementation**:
+```rust
+// Tool parameters
+{
+    "method": "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
+    "endpoint": "/path/to/resource",
+    "body": { ... },  // optional, for POST/PUT/PATCH
+    "headers": { ... },  // optional
+    "query": { ... }  // optional
+}
+```
+
+---
+
+## 6. Error Handling Strategy
+
+**Decision**: Map HTTP status codes to appropriate exit codes and error messages
+
+**Rationale**:
+- CLI scripts need reliable exit codes for flow control
+- Users need actionable error messages, not raw HTTP status
+
+**Exit Code Mapping**:
+| HTTP Status | Exit Code | Meaning |
+|-------------|-----------|---------|
+| 2xx | 0 | Success |
+| 401, 403 | 10 | Authentication error |
+| 400, 422 | 2 | Client/validation error |
+| 404 | 1 | Not found |
+| 429 | 1 | Rate limited (with retry info) |
+| 5xx | 1 | Server error |
+
+---
+
+## 7. Query Parameter Handling
+
+**Decision**: Support `--query key=value` flag (repeatable) with URL encoding
+
+**Rationale**:
+- Clean separation from endpoint path
+- Automatic URL encoding prevents encoding errors
+- Repeatable flag for multiple parameters
+- Matches common CLI patterns (curl `-d`, httpie `==`)
+
+**Alternatives Considered**:
+| Alternative | Reason Rejected |
+|------------|-----------------|
+| Require params in URL string | Error-prone encoding, harder to construct dynamically |
+| JSON object for params | Overly verbose for simple key-value pairs |
+
+**Implementation**:
+```rust
+#[arg(short, long = "query", value_parser = parse_key_value)]
+query: Vec<(String, String)>,
+```
+
+---
+
+## 8. Authentication Flow
+
+**Decision**: Reuse existing auth mechanism; require prior authentication
+
+**Rationale**:
+- `raps auth login` already handles 2-legged, 3-legged, and device code flows
+- Token stored securely in keyring, refreshed automatically
+- No need to duplicate auth logic in custom API command
+
+**Implementation**:
+- Get token via `auth_client.get_token()` or `auth_client.get_3leg_token()`
+- If no token available, display error with `raps auth login` guidance
+- Token added automatically as `Authorization: Bearer {token}` header
+
+---
+
+## Dependencies
+
+No new dependencies required. All functionality can be implemented with existing workspace crates:
+- `raps-kernel`: AuthClient, HttpClientConfig, Config
+- `reqwest`: Direct HTTP requests (already a dependency)
+- `clap`: CLI parsing (already a dependency)
+- `serde_json`: JSON parsing/validation (already a dependency)
+
+---
+
+## Open Items
+
+None. All technical decisions resolved.

--- a/specs/007-custom-api-calls/spec.md
+++ b/specs/007-custom-api-calls/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Custom API Calls
+
+**Feature Branch**: `007-custom-api-calls`
+**Created**: 2026-01-22
+**Status**: Draft
+**Input**: User description: "to cli and mcp add option to run custom api calls, using current auth, appropriate method and endpoint"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Execute Custom GET Request via CLI (Priority: P1)
+
+A developer needs to call an APS API endpoint that RAPS doesn't directly support as a built-in command. They want to make a GET request to retrieve data from a specific endpoint using their currently authenticated session.
+
+**Why this priority**: This is the core functionality that enables users to access any APS API endpoint without waiting for RAPS to add explicit support. GET requests are the most common API operation for retrieving data.
+
+**Independent Test**: Can be fully tested by executing a simple GET request to a known APS endpoint (e.g., `/userprofile/v1/users/@me`) and verifying the response is returned correctly with proper authentication.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has authenticated with RAPS, **When** they execute `raps api get /userprofile/v1/users/@me`, **Then** the system returns the user's profile data in the configured output format
+2. **Given** the user has authenticated with RAPS, **When** they execute a GET request to a valid endpoint with query parameters, **Then** the query parameters are correctly appended to the request
+3. **Given** the user is not authenticated, **When** they attempt to execute a custom API call, **Then** the system displays an authentication error with guidance on how to authenticate
+
+---
+
+### User Story 2 - Execute Custom API Request with Request Body (Priority: P2)
+
+A developer needs to create or update a resource via a custom API endpoint using POST, PUT, or PATCH methods with a JSON request body.
+
+**Why this priority**: Write operations are essential for full API coverage but are used less frequently than read operations. This enables users to perform any CRUD operation on APS resources.
+
+**Independent Test**: Can be fully tested by executing a POST request to create a resource and verifying the response indicates successful creation.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has authenticated, **When** they execute `raps api post /endpoint --data '{"key":"value"}'`, **Then** the system sends the POST request with the JSON body and returns the response
+2. **Given** the user has authenticated, **When** they execute a PUT request with a JSON file as input, **Then** the system reads the file contents and sends them as the request body
+3. **Given** the user provides malformed JSON, **When** they attempt to execute the request, **Then** the system validates the JSON and displays a clear error before sending the request
+
+---
+
+### User Story 3 - Execute Custom API Calls via MCP Tool (Priority: P2)
+
+An AI assistant (or automation tool) needs to make arbitrary API calls to APS through the MCP server when built-in tools don't cover the required endpoint.
+
+**Why this priority**: MCP integration enables AI assistants and automation tools to interact with any APS API, significantly expanding automation capabilities. This has equal priority to CLI body support as both extend core functionality.
+
+**Independent Test**: Can be fully tested by invoking the MCP tool with a simple GET endpoint and verifying the response is returned in the expected MCP format.
+
+**Acceptance Scenarios**:
+
+1. **Given** the MCP server is running with valid authentication, **When** an MCP client invokes `api_request` with method GET and a valid endpoint, **Then** the tool returns the API response as structured data
+2. **Given** the MCP server is running, **When** an MCP client invokes `api_request` with POST method and a body, **Then** the request is sent with the correct content-type and body
+3. **Given** the API returns an error status code, **When** the MCP tool processes the response, **Then** it returns the error in a structured format that includes status code and error message
+
+---
+
+### User Story 4 - Custom Headers and Authentication Override (Priority: P3)
+
+A developer needs to add custom headers to their API request or use a specific authentication method for certain endpoints that require different headers.
+
+**Why this priority**: Most API calls work with default headers and authentication. Custom headers are needed for edge cases like specific content types, versioning headers, or accessing endpoints with special requirements.
+
+**Independent Test**: Can be fully tested by adding a custom header to a request and verifying via the response or request logging that the header was included.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is authenticated, **When** they execute `raps api get /endpoint --header "X-Custom: value"`, **Then** the custom header is included in the request alongside the authentication header
+2. **Given** the user specifies multiple custom headers, **When** the request is sent, **Then** all custom headers are included in the request
+3. **Given** the user wants to specify a different content type, **When** they provide `--header "Content-Type: application/xml"`, **Then** the request is sent with the specified content type
+
+---
+
+### Edge Cases
+
+- What happens when the endpoint returns a non-JSON response (binary, XML, HTML)?
+  - The system should detect the content type and handle appropriately: display text-based responses as-is, save binary responses to a file with `--output` flag
+- How does the system handle API rate limiting (429 responses)?
+  - The system should respect rate limiting by displaying the retry-after information and optionally auto-retrying with the existing retry logic
+- What happens when the endpoint URL is malformed?
+  - The system should validate the URL format before sending and display a clear validation error
+- How are very large response bodies handled?
+  - The system should stream large responses and support saving to file with `--output` flag to avoid memory issues
+- What happens when the user provides both `--data` and `--data-file`?
+  - The system should reject this as an invalid combination with a clear error message
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a CLI command group `raps api` for executing custom API calls
+- **FR-002**: System MUST support HTTP methods via subcommands: `raps api get`, `raps api post`, `raps api put`, `raps api patch`, `raps api delete`
+- **FR-003**: System MUST automatically use the current authenticated session's access token for all requests
+- **FR-004**: System MUST allow users to specify the API endpoint path (relative to the APS base URL)
+- **FR-005**: System MUST restrict requests to APS domains only (developer.api.autodesk.com and related Autodesk API hosts); external URLs are not permitted
+- **FR-006**: System MUST support query parameters via `--query` or `--param` flags
+- **FR-007**: System MUST support request body input via `--data` flag for inline JSON
+- **FR-008**: System MUST support request body input via `--data-file` flag to read from a file
+- **FR-009**: System MUST validate JSON input before sending requests
+- **FR-010**: System MUST support custom headers via `--header` flag (repeatable)
+- **FR-011**: System MUST display response body in the configured output format (JSON, YAML, table, CSV)
+- **FR-012**: System MUST display HTTP status code and response headers when `--verbose` is enabled
+- **FR-013**: System MUST provide an MCP tool `api_request` for executing custom API calls
+- **FR-014**: System MUST return appropriate exit codes for CLI (0 for 2xx success, non-zero for errors)
+- **FR-015**: System MUST support saving response body to a file via `--output` flag
+- **FR-016**: System MUST handle non-JSON responses gracefully (display as text or save as binary)
+- **FR-017**: System MUST support the existing retry logic for transient failures (5xx errors, network issues)
+
+### Key Entities
+
+- **API Request**: Represents a custom API call with method, endpoint, headers, query parameters, and optional body
+- **API Response**: Contains status code, headers, body content, and content type
+- **Authentication Context**: The current session's access token and token type used for Authorization header
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can successfully call any valid APS API endpoint within 5 seconds for typical responses
+- **SC-002**: 100% of supported HTTP methods (GET, POST, PUT, PATCH, DELETE) work correctly for both CLI and MCP
+- **SC-003**: Users can complete a custom API call with the same number of steps as using curl directly (endpoint + method + optional body)
+- **SC-004**: Error messages clearly indicate the issue (authentication, validation, network, API error) with actionable guidance
+- **SC-005**: Response output matches the globally configured format without additional user intervention
+- **SC-006**: MCP tool response time is equivalent to direct CLI execution (within 10% overhead)
+
+## Clarifications
+
+### Session 2026-01-22
+
+- Q: Should custom API calls allow requests to any arbitrary URL, or be restricted to APS domains? → A: APS domains only - no external URLs permitted
+- Q: Should HTTP methods be specified via subcommands or a --method flag? → A: Subcommands (`raps api get`, `raps api post`, etc.)
+
+## Assumptions
+
+- The existing authentication system and token refresh mechanism will be reused without modification
+- The base URL for APS APIs follows the existing pattern already configured in RAPS
+- The existing output format flags (`--output-format`, global config) apply to custom API responses
+- The existing HTTP client with retry logic will be leveraged for custom API calls
+- Query parameters follow standard URL encoding conventions

--- a/specs/007-custom-api-calls/tasks.md
+++ b/specs/007-custom-api-calls/tasks.md
@@ -1,0 +1,253 @@
+# Tasks: Custom API Calls
+
+**Input**: Design documents from `/specs/007-custom-api-calls/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Tests included based on plan.md (cargo test, assert_cmd integration tests)
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Based on plan.md structure:
+- CLI commands: `raps-cli/src/commands/`
+- MCP server: `raps-cli/src/mcp/`
+- Kernel utilities: `raps-kernel/src/`
+- Tests: `raps-cli/tests/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Module scaffolding and exports
+
+- [ ] T001 Create empty api.rs command module in raps-cli/src/commands/api.rs
+- [ ] T002 Add api module export in raps-cli/src/commands/mod.rs
+- [ ] T003 Add Api variant to Commands enum in raps-cli/src/main.rs
+
+**Checkpoint**: Project compiles with empty api command stub
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure shared by all user stories - domain validation and data types
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Add ALLOWED_DOMAINS constant and is_allowed_url() validation function in raps-kernel/src/http.rs
+- [ ] T005 [P] Define HttpMethod enum in raps-cli/src/commands/api.rs
+- [ ] T006 [P] Define ApiRequest struct with method, endpoint, headers, query_params, body fields in raps-cli/src/commands/api.rs
+- [ ] T007 [P] Define ApiResponse struct with status_code, headers, content_type, body in raps-cli/src/commands/api.rs
+- [ ] T008 [P] Define ResponseBody enum (Json, Text, Binary variants) in raps-cli/src/commands/api.rs
+- [ ] T009 [P] Define ApiError struct for error responses in raps-cli/src/commands/api.rs
+- [ ] T010 Add unit tests for is_allowed_url() function in raps-kernel/src/http.rs
+
+**Checkpoint**: Foundation ready - domain validation works, data types defined
+
+---
+
+## Phase 3: User Story 1 - Execute Custom GET Request via CLI (Priority: P1) 🎯 MVP
+
+**Goal**: Users can execute GET requests to any APS endpoint with query parameters and output formatting
+
+**Independent Test**: Run `raps api get /userprofile/v1/users/@me` and verify response with proper auth
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Define ApiCommands enum with Get variant (endpoint, query, header, output, verbose args) in raps-cli/src/commands/api.rs
+- [ ] T012 [US1] Implement parse_key_value() helper for --query KEY=VALUE parsing in raps-cli/src/commands/api.rs
+- [ ] T013 [US1] Implement parse_header() helper for --header KEY:VALUE parsing in raps-cli/src/commands/api.rs
+- [ ] T014 [US1] Implement build_url() to construct full URL from base + endpoint + query params in raps-cli/src/commands/api.rs
+- [ ] T015 [US1] Implement execute_request() async function for HTTP GET with auth token in raps-cli/src/commands/api.rs
+- [ ] T016 [US1] Implement handle_response() to detect content-type and parse response body in raps-cli/src/commands/api.rs
+- [ ] T017 [US1] Implement format_output() to display response using OutputFormat (json/yaml/table/csv) in raps-cli/src/commands/api.rs
+- [ ] T018 [US1] Implement verbose output showing HTTP status and headers in raps-cli/src/commands/api.rs
+- [ ] T019 [US1] Implement --output flag to save response to file in raps-cli/src/commands/api.rs
+- [ ] T020 [US1] Add authentication check with helpful error message when not logged in in raps-cli/src/commands/api.rs
+- [ ] T021 [US1] Wire up ApiCommands::execute() dispatch in raps-cli/src/main.rs
+- [ ] T022 [US1] Add integration test for `raps api get --help` in raps-cli/tests/api_tests.rs
+- [ ] T023 [US1] Add integration test for GET request validation errors in raps-cli/tests/api_tests.rs
+
+**Checkpoint**: User Story 1 complete - GET requests work with query params, output formats, auth
+
+---
+
+## Phase 4: User Story 2 - Execute Custom API Request with Body (Priority: P2)
+
+**Goal**: Users can execute POST/PUT/PATCH requests with JSON body from inline or file
+
+**Independent Test**: Run `raps api post /oss/v2/buckets --data '{"bucketKey":"test"}'` and verify request sent
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Add Post, Put, Patch, Delete variants to ApiCommands enum with --data and --data-file args in raps-cli/src/commands/api.rs
+- [ ] T025 [US2] Implement read_body_from_file() to load JSON from --data-file path in raps-cli/src/commands/api.rs
+- [ ] T026 [US2] Implement validate_json() to parse and validate JSON body before sending in raps-cli/src/commands/api.rs
+- [ ] T027 [US2] Add clap conflicts_with constraint between --data and --data-file in raps-cli/src/commands/api.rs
+- [ ] T028 [US2] Implement execute_request() for POST/PUT/PATCH with Content-Type: application/json header in raps-cli/src/commands/api.rs
+- [ ] T029 [US2] Implement execute_request() for DELETE method (no body) in raps-cli/src/commands/api.rs
+- [ ] T030 [US2] Add validation error when body provided for GET/DELETE in raps-cli/src/commands/api.rs
+- [ ] T031 [US2] Add integration test for POST with inline --data in raps-cli/tests/api_tests.rs
+- [ ] T032 [US2] Add integration test for --data and --data-file mutual exclusion in raps-cli/tests/api_tests.rs
+
+**Checkpoint**: User Story 2 complete - POST/PUT/PATCH/DELETE work with JSON bodies
+
+---
+
+## Phase 5: User Story 3 - Execute Custom API Calls via MCP Tool (Priority: P2)
+
+**Goal**: MCP clients can invoke api_request tool for arbitrary APS API calls
+
+**Independent Test**: Invoke api_request MCP tool with GET /oss/v2/buckets and verify structured response
+
+### Implementation for User Story 3
+
+- [ ] T033 [US3] Add "api_request" to TOOLS constant in raps-cli/src/mcp/tools.rs
+- [ ] T034 [US3] Add get_tools() entry for api_request with JSON schema (method, endpoint, body, headers, query) in raps-cli/src/mcp/server.rs
+- [ ] T035 [US3] Implement api_request() method on RapsServer with parameter parsing in raps-cli/src/mcp/server.rs
+- [ ] T036 [US3] Add api_request dispatch case in dispatch_tool() match in raps-cli/src/mcp/server.rs
+- [ ] T037 [US3] Implement MCP response formatting (success: bool, status, data/error) in raps-cli/src/mcp/server.rs
+- [ ] T038 [US3] Add validation for method enum values in MCP tool in raps-cli/src/mcp/server.rs
+- [ ] T039 [US3] Add domain validation for endpoint in MCP tool in raps-cli/src/mcp/server.rs
+- [ ] T040 [US3] Add body-not-allowed validation for GET/DELETE in MCP tool in raps-cli/src/mcp/server.rs
+
+**Checkpoint**: User Story 3 complete - MCP api_request tool works for all methods
+
+---
+
+## Phase 6: User Story 4 - Custom Headers (Priority: P3)
+
+**Goal**: Users can add custom headers to requests via --header flag (repeatable)
+
+**Independent Test**: Run `raps api get /endpoint --header "X-Custom:value"` and verify header included
+
+### Implementation for User Story 4
+
+- [ ] T041 [US4] Implement repeatable --header flag collection in clap args in raps-cli/src/commands/api.rs
+- [ ] T042 [US4] Add custom headers to reqwest RequestBuilder in execute_request() in raps-cli/src/commands/api.rs
+- [ ] T043 [US4] Ensure Authorization header cannot be overridden by user in raps-cli/src/commands/api.rs
+- [ ] T044 [US4] Add custom headers support in MCP api_request tool in raps-cli/src/mcp/server.rs
+- [ ] T045 [US4] Add integration test for multiple custom headers in raps-cli/tests/api_tests.rs
+
+**Checkpoint**: User Story 4 complete - Custom headers work for CLI and MCP
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Error handling, edge cases, and documentation
+
+- [ ] T046 [P] Implement exit code mapping (0=2xx, 1=4xx/5xx, 2=validation, 10=auth) in raps-cli/src/commands/api.rs
+- [ ] T047 [P] Handle non-JSON responses: text display, binary save-to-file in raps-cli/src/commands/api.rs
+- [ ] T048 [P] Add retry logic integration for 5xx and network errors in raps-cli/src/commands/api.rs
+- [ ] T049 [P] Add rate limiting (429) handling with retry-after display in raps-cli/src/commands/api.rs
+- [ ] T050 Run quickstart.md validation - verify all examples work
+- [ ] T051 Run cargo clippy and fix any warnings
+- [ ] T052 Run cargo fmt to ensure code formatting
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - US1 (P1): MVP - implement first
+  - US2 (P2): Can start after US1 or in parallel
+  - US3 (P2): Can start after US1 or in parallel (different files)
+  - US4 (P3): Can start after US1 or in parallel
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: After Foundational - No dependencies on other stories
+- **User Story 2 (P2)**: After Foundational - Extends US1 execute_request() but independently testable
+- **User Story 3 (P2)**: After Foundational - Different files (mcp/), can parallel with US1/US2
+- **User Story 4 (P3)**: After Foundational - Extends US1 header handling but independently testable
+
+### Within Each User Story
+
+- Data types before functions
+- Helper functions before main logic
+- Core implementation before error handling
+- Integration tests after implementation
+
+### Parallel Opportunities
+
+**Phase 2 (Foundational)**:
+```
+T005, T006, T007, T008, T009 can run in parallel (different struct definitions)
+```
+
+**Phase 3-6 (User Stories)**:
+```
+US3 (MCP) can run in parallel with US1/US2 (different file: mcp/server.rs vs commands/api.rs)
+```
+
+**Phase 7 (Polish)**:
+```
+T046, T047, T048, T049 can run in parallel (independent error handling aspects)
+```
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch data type definitions in parallel:
+Task: "Define HttpMethod enum in raps-cli/src/commands/api.rs"
+Task: "Define ApiRequest struct in raps-cli/src/commands/api.rs"
+Task: "Define ApiResponse struct in raps-cli/src/commands/api.rs"
+Task: "Define ResponseBody enum in raps-cli/src/commands/api.rs"
+Task: "Define ApiError struct in raps-cli/src/commands/api.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (3 tasks)
+2. Complete Phase 2: Foundational (7 tasks)
+3. Complete Phase 3: User Story 1 (13 tasks)
+4. **STOP and VALIDATE**: Test `raps api get` works
+5. Deploy/demo if ready - users can already make GET requests!
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready (10 tasks)
+2. Add User Story 1 → MVP: GET requests work (23 tasks total)
+3. Add User Story 2 → POST/PUT/PATCH/DELETE work (32 tasks total)
+4. Add User Story 3 → MCP integration works (40 tasks total)
+5. Add User Story 4 → Custom headers work (45 tasks total)
+6. Polish → Production ready (52 tasks total)
+
+### Parallel Team Strategy
+
+With multiple developers after Foundational:
+
+- **Developer A**: User Story 1 (CLI GET) + User Story 2 (CLI body methods)
+- **Developer B**: User Story 3 (MCP tool) + User Story 4 (custom headers)
+
+Different files, minimal conflicts.
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent code paths
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently testable after completion
+- Reuse existing raps-kernel auth and HTTP client - no new crates needed
+- Domain validation (is_allowed_url) is security-critical - test thoroughly
+- MCP tool shares core logic with CLI but has different I/O format


### PR DESCRIPTION
## Summary
- Add `raps api` CLI commands (get, post, put, patch, delete) for executing custom HTTP requests to APS endpoints
- Add `api_request` MCP tool for AI assistant integration
- Implement domain validation restricting requests to APS domains only for security

## Changes
- **CLI**: New `raps api <method> <endpoint>` commands with query params, headers, body support
- **MCP**: New `api_request` tool (56 total tools now)
- **Security**: URL allowlist validation in `raps-kernel/src/http.rs`
- **Tests**: 10 integration tests + 11 unit tests for URL validation

## Test plan
- [x] All 10 api_tests pass
- [x] All 11 is_allowed_url tests pass
- [x] Clippy passes with no warnings
- [x] Help text displays correctly for all subcommands

🤖 Generated with [Claude Code](https://claude.ai/code)