### PR TITLE
test: add insta snapshot + swarm CLI integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+dependencies = [
+ "console 0.15.11",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1883,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2288,6 +2346,7 @@ dependencies = [
  "dotenvy",
  "hostname",
  "indicatif",
+ "insta",
  "keyring",
  "lru",
  "memory-stats",
@@ -2952,6 +3011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3539,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ predicates = "3.1"
 raps-mock = { git = "https://github.com/dmytro-yemelianov/raps-mock.git", tag = "v0.2.0" }
 tokio-test = "0.4"
 tempfile = "3.26"
+insta = { version = "1.42", features = ["yaml", "json", "redactions"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/raps-cli/tests/swarm_commands.rs
+++ b/raps-cli/tests/swarm_commands.rs
@@ -1,0 +1,76 @@
+//! Integration tests for swarm subcommands.
+//!
+//! Tests help output, subcommand presence, and graceful failure modes
+//! for the distributed worker CLI. Worker-specific tests require the
+//! `redis` feature flag.
+
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn raps() -> Command {
+    Command::cargo_bin("raps").unwrap()
+}
+
+// ==================== Swarm Top-Level ====================
+
+#[test]
+fn test_swarm_subcommands_exist() {
+    raps()
+        .args(["swarm", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("metrics"))
+        .stdout(predicate::str::contains("queue"))
+        .stdout(predicate::str::contains("resume"))
+        .stdout(predicate::str::contains("audit"))
+        .stdout(predicate::str::contains("reset"));
+}
+
+#[test]
+fn test_swarm_status_help() {
+    raps()
+        .args(["swarm", "status", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("circuit breaker").or(predicate::str::contains("rate")));
+}
+
+// ==================== Worker (redis feature) ====================
+
+#[cfg(feature = "redis")]
+#[test]
+fn test_swarm_worker_help() {
+    raps()
+        .args(["swarm", "worker", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("start").or(predicate::str::contains("Start")));
+}
+
+#[cfg(feature = "redis")]
+#[test]
+fn test_swarm_worker_start_help() {
+    raps()
+        .args(["swarm", "worker", "start", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--redis-url"))
+        .stdout(predicate::str::contains("--concurrency"))
+        .stdout(predicate::str::contains("--heartbeat-secs"))
+        .stdout(predicate::str::contains("--metrics-port"));
+}
+
+#[cfg(feature = "redis")]
+#[test]
+fn test_swarm_worker_start_missing_redis() {
+    // Worker start should fail gracefully when Redis is unreachable.
+    // Use a bogus URL to ensure no accidental connection to a real instance.
+    raps()
+        .args(["swarm", "worker", "start", "--redis-url", "redis://127.0.0.1:1"])
+        .timeout(std::time::Duration::from_secs(10))
+        .assert()
+        .failure();
+}

--- a/raps-kernel/Cargo.toml
+++ b/raps-kernel/Cargo.toml
@@ -107,3 +107,4 @@ raps-mock.workspace = true
 tokio-test.workspace = true
 tempfile.workspace = true
 tower = { version = "0.5", features = ["util"] }
+insta.workspace = true

--- a/raps-kernel/src/health_server.rs
+++ b/raps-kernel/src/health_server.rs
@@ -180,4 +180,81 @@ mod tests {
             .unwrap();
         assert!(content_type.contains("text/plain"));
     }
+
+    // ==================== Snapshot Contract Tests ====================
+
+    #[tokio::test]
+    async fn test_health_response_body() {
+        let state = test_state(true);
+        let response = app(state)
+            .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        insta::assert_json_snapshot!(json);
+    }
+
+    #[tokio::test]
+    async fn test_ready_response_body() {
+        let state = test_state(true);
+        let response = app(state)
+            .oneshot(Request::builder().uri("/ready").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        insta::assert_json_snapshot!(json);
+    }
+
+    #[tokio::test]
+    async fn test_not_ready_response_body() {
+        let state = test_state(false);
+        let response = app(state)
+            .oneshot(Request::builder().uri("/ready").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        insta::assert_json_snapshot!(json);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_response_with_data() {
+        let state = test_state(true);
+        state.exporter.set_queue_depth("high", 5.0);
+        state.exporter.set_queue_depth("normal", 12.0);
+        state
+            .exporter
+            .jobs_processed_total
+            .with_label_values(&["high", "success"])
+            .inc_by(50.0);
+
+        let response = app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        insta::assert_snapshot!(text);
+    }
 }

--- a/raps-kernel/src/prometheus_metrics.rs
+++ b/raps-kernel/src/prometheus_metrics.rs
@@ -177,57 +177,14 @@ impl PrometheusExporter {
 mod tests {
     use super::*;
 
+    // ==================== Behavioral Tests ====================
+
     #[test]
     fn test_new_exporter() {
         let exporter = PrometheusExporter::new();
         let output = exporter.render();
         // Empty registry should still produce valid output
         assert!(output.is_empty() || output.contains("# HELP") || !output.contains("ERROR"));
-    }
-
-    #[test]
-    fn test_queue_depth() {
-        let exporter = PrometheusExporter::new();
-        exporter.set_queue_depth("high", 42.0);
-        exporter.set_queue_depth("normal", 10.0);
-        let output = exporter.render();
-        assert!(output.contains("raps_queue_depth"));
-        assert!(output.contains("42"));
-    }
-
-    #[test]
-    fn test_jobs_processed() {
-        let exporter = PrometheusExporter::new();
-        exporter
-            .jobs_processed_total
-            .with_label_values(&["high", "success"])
-            .inc_by(5.0);
-        let output = exporter.render();
-        assert!(output.contains("raps_jobs_processed_total"));
-        assert!(output.contains("5"));
-    }
-
-    #[test]
-    fn test_job_duration() {
-        let exporter = PrometheusExporter::new();
-        exporter
-            .job_duration_seconds
-            .with_label_values(&["translate"])
-            .observe(45.0);
-        let output = exporter.render();
-        assert!(output.contains("raps_job_duration_seconds"));
-    }
-
-    #[test]
-    fn test_worker_info() {
-        let exporter = PrometheusExporter::new();
-        exporter
-            .worker_info
-            .with_label_values(&["worker-1", "5.2.0"])
-            .set(1.0);
-        let output = exporter.render();
-        assert!(output.contains("raps_worker_info"));
-        assert!(output.contains("worker-1"));
     }
 
     #[test]
@@ -250,13 +207,104 @@ mod tests {
         assert!(output.contains("raps_cache_hits_total"));
     }
 
+    // ==================== Snapshot Contract Tests ====================
+
     #[test]
-    fn test_render_format() {
+    fn test_render_empty() {
         let exporter = PrometheusExporter::new();
-        exporter.set_queue_depth("high", 1.0);
         let output = exporter.render();
-        // Should be valid Prometheus text format
-        assert!(output.contains("# HELP raps_queue_depth"));
-        assert!(output.contains("# TYPE raps_queue_depth gauge"));
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_render_queue_depth() {
+        let exporter = PrometheusExporter::new();
+        exporter.set_queue_depth("high", 42.0);
+        exporter.set_queue_depth("normal", 10.0);
+        let output = exporter.render();
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_render_full_metrics() {
+        let exporter = PrometheusExporter::new();
+
+        // Queue depths
+        exporter.set_queue_depth("critical", 3.0);
+        exporter.set_queue_depth("normal", 15.0);
+        exporter.set_queue_depth("background", 42.0);
+
+        // Jobs processed
+        exporter
+            .jobs_processed_total
+            .with_label_values(&["critical", "success"])
+            .inc_by(100.0);
+        exporter
+            .jobs_processed_total
+            .with_label_values(&["normal", "failure"])
+            .inc_by(2.0);
+
+        // Job duration
+        exporter
+            .job_duration_seconds
+            .with_label_values(&["translate"])
+            .observe(45.0);
+
+        // API requests
+        exporter
+            .api_requests_total
+            .with_label_values(&["/oss/v2/buckets"])
+            .inc_by(500.0);
+
+        // API errors
+        exporter
+            .api_errors_total
+            .with_label_values(&["/oss/v2/buckets"])
+            .inc_by(3.0);
+
+        // Cache hits
+        exporter
+            .cache_hits_total
+            .with_label_values(&["/oss/v2/buckets"])
+            .inc_by(120.0);
+
+        // Worker info
+        exporter
+            .worker_info
+            .with_label_values(&["worker-1", "5.0.0"])
+            .set(1.0);
+
+        let output = exporter.render();
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_sync_from_collector_render() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.json");
+        let collector = MetricsCollector::new(path).unwrap();
+
+        collector.record_api_request("oss", 100);
+        collector.record_api_request("oss", 200);
+        collector.record_api_error("oss");
+        collector.record_cache_hit("oss");
+
+        let exporter = PrometheusExporter::new();
+        exporter.sync_from_collector(&collector);
+
+        let output = exporter.render();
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_histogram_buckets() {
+        let exporter = PrometheusExporter::new();
+        // Observe a single value to force bucket output
+        exporter
+            .job_duration_seconds
+            .with_label_values(&["translate"])
+            .observe(45.0);
+        let output = exporter.render();
+        insta::assert_snapshot!(output);
     }
 }

--- a/raps-kernel/src/snapshots/raps_kernel__health_server__tests__health_response_body.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__health_server__tests__health_response_body.snap
@@ -1,0 +1,8 @@
+---
+source: raps-kernel/src/health_server.rs
+assertion_line: 198
+expression: json
+---
+{
+  "status": "ok"
+}

--- a/raps-kernel/src/snapshots/raps_kernel__health_server__tests__metrics_response_with_data.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__health_server__tests__metrics_response_with_data.snap
@@ -1,0 +1,12 @@
+---
+source: raps-kernel/src/health_server.rs
+assertion_line: 258
+expression: text
+---
+# HELP raps_jobs_processed_total Total jobs processed
+# TYPE raps_jobs_processed_total counter
+raps_jobs_processed_total{priority="high",status="success"} 50
+# HELP raps_queue_depth Number of jobs waiting in queue
+# TYPE raps_queue_depth gauge
+raps_queue_depth{priority="high"} 5
+raps_queue_depth{priority="normal"} 12

--- a/raps-kernel/src/snapshots/raps_kernel__health_server__tests__not_ready_response_body.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__health_server__tests__not_ready_response_body.snap
@@ -1,0 +1,8 @@
+---
+source: raps-kernel/src/health_server.rs
+assertion_line: 229
+expression: json
+---
+{
+  "status": "not_ready"
+}

--- a/raps-kernel/src/snapshots/raps_kernel__health_server__tests__ready_response_body.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__health_server__tests__ready_response_body.snap
@@ -1,0 +1,8 @@
+---
+source: raps-kernel/src/health_server.rs
+assertion_line: 213
+expression: json
+---
+{
+  "status": "ready"
+}

--- a/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__histogram_buckets.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__histogram_buckets.snap
@@ -1,0 +1,19 @@
+---
+source: raps-kernel/src/prometheus_metrics.rs
+assertion_line: 308
+expression: output
+---
+# HELP raps_job_duration_seconds Job processing duration in seconds
+# TYPE raps_job_duration_seconds histogram
+raps_job_duration_seconds_bucket{job_type="translate",le="1"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="5"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="15"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="30"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="60"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="120"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="300"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="600"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="1800"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="+Inf"} 1
+raps_job_duration_seconds_sum{job_type="translate"} 45
+raps_job_duration_seconds_count{job_type="translate"} 1

--- a/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__render_empty.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__render_empty.snap
@@ -1,0 +1,6 @@
+---
+source: raps-kernel/src/prometheus_metrics.rs
+assertion_line: 216
+expression: output
+---
+

--- a/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__render_full_metrics.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__render_full_metrics.snap
@@ -1,0 +1,40 @@
+---
+source: raps-kernel/src/prometheus_metrics.rs
+assertion_line: 278
+expression: output
+---
+# HELP raps_api_errors_total Total API errors
+# TYPE raps_api_errors_total counter
+raps_api_errors_total{endpoint="/oss/v2/buckets"} 3
+# HELP raps_api_requests_total Total API requests
+# TYPE raps_api_requests_total counter
+raps_api_requests_total{endpoint="/oss/v2/buckets"} 500
+# HELP raps_cache_hits_total Total cache hits
+# TYPE raps_cache_hits_total counter
+raps_cache_hits_total{endpoint="/oss/v2/buckets"} 120
+# HELP raps_job_duration_seconds Job processing duration in seconds
+# TYPE raps_job_duration_seconds histogram
+raps_job_duration_seconds_bucket{job_type="translate",le="1"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="5"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="15"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="30"} 0
+raps_job_duration_seconds_bucket{job_type="translate",le="60"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="120"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="300"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="600"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="1800"} 1
+raps_job_duration_seconds_bucket{job_type="translate",le="+Inf"} 1
+raps_job_duration_seconds_sum{job_type="translate"} 45
+raps_job_duration_seconds_count{job_type="translate"} 1
+# HELP raps_jobs_processed_total Total jobs processed
+# TYPE raps_jobs_processed_total counter
+raps_jobs_processed_total{priority="critical",status="success"} 100
+raps_jobs_processed_total{priority="normal",status="failure"} 2
+# HELP raps_queue_depth Number of jobs waiting in queue
+# TYPE raps_queue_depth gauge
+raps_queue_depth{priority="background"} 42
+raps_queue_depth{priority="critical"} 3
+raps_queue_depth{priority="normal"} 15
+# HELP raps_worker_info Worker metadata
+# TYPE raps_worker_info gauge
+raps_worker_info{version="5.0.0",worker_id="worker-1"} 1

--- a/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__render_queue_depth.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__render_queue_depth.snap
@@ -1,0 +1,9 @@
+---
+source: raps-kernel/src/prometheus_metrics.rs
+assertion_line: 225
+expression: output
+---
+# HELP raps_queue_depth Number of jobs waiting in queue
+# TYPE raps_queue_depth gauge
+raps_queue_depth{priority="high"} 42
+raps_queue_depth{priority="normal"} 10

--- a/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__sync_from_collector_render.snap
+++ b/raps-kernel/src/snapshots/raps_kernel__prometheus_metrics__tests__sync_from_collector_render.snap
@@ -1,0 +1,14 @@
+---
+source: raps-kernel/src/prometheus_metrics.rs
+assertion_line: 296
+expression: output
+---
+# HELP raps_api_errors_total Total API errors
+# TYPE raps_api_errors_total counter
+raps_api_errors_total{endpoint="oss"} 1
+# HELP raps_api_requests_total Total API requests
+# TYPE raps_api_requests_total counter
+raps_api_requests_total{endpoint="oss"} 2
+# HELP raps_cache_hits_total Total cache hits
+# TYPE raps_cache_hits_total counter
+raps_cache_hits_total{endpoint="oss"} 1


### PR DESCRIPTION
## Summary
- Add `insta` snapshot testing for Prometheus metrics wire format and health endpoint JSON contracts
- Replace shallow `contains()` assertions with exact snapshot comparisons that lock down the scraping contract
- Add 5 CLI integration tests for `raps swarm` subcommands (help, flags, graceful Redis failure)

## Test plan
- [x] `cargo test -p raps-kernel --features kubernetes` — 16 pass (9 new snapshots + 7 existing)
- [x] `cargo test -p raps-cli --features redis,kubernetes --test swarm_commands` — 5 pass
- [x] `cargo test --workspace` — full regression green

🤖 Generated with [Claude Code](https://claude.com/claude-code)