### PR TITLE
fix: resolve serve.rs compilation errors and clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1194,6 +1195,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -2234,6 +2244,7 @@ version = "5.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "axum 0.8.8",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -2243,12 +2254,14 @@ dependencies = [
  "console 0.15.11",
  "crossterm 0.28.1",
  "csv",
+ "deadpool-redis",
  "dialoguer",
  "directories",
  "dotenvy",
  "ed25519-dalek",
  "futures-util",
  "hex",
+ "hmac",
  "hostname",
  "indicatif",
  "insta",

--- a/raps-cli/Cargo.toml
+++ b/raps-cli/Cargo.toml
@@ -114,6 +114,7 @@ hostname = { workspace = true, optional = true }
 
 # Redis client (optional, for distributed worker)
 redis = { workspace = true, optional = true }
+deadpool-redis = { workspace = true, optional = true }
 
 # HTTP server for Kubernetes service components (optional)
 axum = { workspace = true, optional = true }
@@ -121,7 +122,7 @@ axum = { workspace = true, optional = true }
 [features]
 default = []
 dashboard = ["ratatui", "crossterm"]
-redis = ["raps-kernel/redis", "dep:hostname", "dep:redis"]
+redis = ["raps-kernel/redis", "dep:hostname", "dep:redis", "dep:deadpool-redis"]
 kubernetes = ["raps-kernel/kubernetes", "redis", "dep:axum"]
 
 [dev-dependencies]

--- a/raps-cli/src/commands/serve.rs
+++ b/raps-cli/src/commands/serve.rs
@@ -26,6 +26,9 @@ use raps_kernel::job_queue::{Job, JobPayload, JobPriority, JobProducer};
 use raps_kernel::prometheus_metrics::PrometheusExporter;
 use raps_kernel::redis_backend::RedisBackend;
 
+/// Redis XREVRANGE result type: Vec<(entry_id, [(field, value), ...])>
+type StreamEntries = Vec<(String, Vec<(String, String)>)>;
+
 // ---------------------------------------------------------------------------
 // CLI subcommands
 // ---------------------------------------------------------------------------
@@ -294,8 +297,7 @@ async fn proxy_forward(
     // Check rate budget — group by first two path segments (e.g. /oss/v2 → "oss")
     let endpoint = path
         .split('/')
-        .filter(|s| !s.is_empty())
-        .next()
+        .find(|s| !s.is_empty())
         .unwrap_or("unknown")
         .to_string();
     let registry = raps_kernel::rate_budget::registry();
@@ -480,7 +482,7 @@ async fn list_jobs(State(state): State<ServiceState>) -> impl IntoResponse {
 
     for priority in JobPriority::all() {
         let stream = priority.stream_key();
-        let result: Result<Vec<(String, Vec<(String, String)>)>, redis::RedisError> =
+        let result: Result<StreamEntries, redis::RedisError> =
             redis::cmd("XREVRANGE")
                 .arg(stream)
                 .arg("+")
@@ -493,17 +495,17 @@ async fn list_jobs(State(state): State<ServiceState>) -> impl IntoResponse {
         if let Ok(entries) = result {
             for (entry_id, fields) in entries {
                 let data = fields.iter().find(|(k, _)| k == "data").map(|(_, v)| v);
-                if let Some(json_str) = data {
-                    if let Ok(job) = serde_json::from_str::<Job>(json_str) {
-                        all_jobs.push(serde_json::json!({
-                            "entry_id": entry_id,
-                            "id": job.id,
-                            "priority": job.priority,
-                            "payload_type": payload_type_name(&job.payload),
-                            "attempts": job.attempts,
-                            "created_at": job.created_at,
-                        }));
-                    }
+                if let Some(json_str) = data
+                    && let Ok(job) = serde_json::from_str::<Job>(json_str)
+                {
+                    all_jobs.push(serde_json::json!({
+                        "entry_id": entry_id,
+                        "id": job.id,
+                        "priority": job.priority,
+                        "payload_type": payload_type_name(&job.payload),
+                        "attempts": job.attempts,
+                        "created_at": job.created_at,
+                    }));
                 }
             }
         }
@@ -527,7 +529,7 @@ async fn get_job(
 
     for priority in JobPriority::all() {
         let stream = priority.stream_key();
-        let result: Result<Vec<(String, Vec<(String, String)>)>, redis::RedisError> =
+        let result: Result<StreamEntries, redis::RedisError> =
             redis::cmd("XREVRANGE")
                 .arg(stream)
                 .arg("+")
@@ -540,25 +542,24 @@ async fn get_job(
         if let Ok(entries) = result {
             for (entry_id, fields) in entries {
                 let data = fields.iter().find(|(k, _)| k == "data").map(|(_, v)| v);
-                if let Some(json_str) = data {
-                    if let Ok(job) = serde_json::from_str::<Job>(json_str) {
-                        if job.id == id {
-                            return (
-                                StatusCode::OK,
-                                Json(serde_json::json!({
-                                    "entry_id": entry_id,
-                                    "id": job.id,
-                                    "priority": job.priority,
-                                    "payload": job.payload,
-                                    "attempts": job.attempts,
-                                    "max_attempts": job.max_attempts,
-                                    "created_at": job.created_at,
-                                    "enqueued_by": job.enqueued_by,
-                                })),
-                            )
-                                .into_response();
-                        }
-                    }
+                if let Some(json_str) = data
+                    && let Ok(job) = serde_json::from_str::<Job>(json_str)
+                    && job.id == id
+                {
+                    return (
+                        StatusCode::OK,
+                        Json(serde_json::json!({
+                            "entry_id": entry_id,
+                            "id": job.id,
+                            "priority": job.priority,
+                            "payload": job.payload,
+                            "attempts": job.attempts,
+                            "max_attempts": job.max_attempts,
+                            "created_at": job.created_at,
+                            "enqueued_by": job.enqueued_by,
+                        })),
+                    )
+                        .into_response();
                 }
             }
         }
@@ -952,7 +953,7 @@ async fn dashboard_queues(State(state): State<ServiceState>) -> impl IntoRespons
         .into_response()
 }
 
-async fn dashboard_metrics(State(state): State<ServiceState>) -> impl IntoResponse {
+async fn dashboard_metrics(State(_state): State<ServiceState>) -> impl IntoResponse {
     // Aggregate rate budget snapshot
     let rate_budgets = raps_kernel::rate_budget::registry().snapshot();
     let cache_stats = raps_kernel::response_cache::cache();
@@ -989,7 +990,7 @@ async fn dashboard_recent_jobs(State(state): State<ServiceState>) -> impl IntoRe
 
     for priority in JobPriority::all() {
         let stream = priority.stream_key();
-        let result: Result<Vec<(String, Vec<(String, String)>)>, redis::RedisError> =
+        let result: Result<StreamEntries, redis::RedisError> =
             redis::cmd("XREVRANGE")
                 .arg(stream)
                 .arg("+")
@@ -1002,17 +1003,17 @@ async fn dashboard_recent_jobs(State(state): State<ServiceState>) -> impl IntoRe
         if let Ok(entries) = result {
             for (entry_id, fields) in entries {
                 let data = fields.iter().find(|(k, _)| k == "data").map(|(_, v)| v);
-                if let Some(json_str) = data {
-                    if let Ok(job) = serde_json::from_str::<Job>(json_str) {
-                        jobs.push(serde_json::json!({
-                            "entry_id": entry_id,
-                            "id": job.id,
-                            "priority": job.priority,
-                            "type": payload_type_name(&job.payload),
-                            "attempts": job.attempts,
-                            "created_at": job.created_at,
-                        }));
-                    }
+                if let Some(json_str) = data
+                    && let Ok(job) = serde_json::from_str::<Job>(json_str)
+                {
+                    jobs.push(serde_json::json!({
+                        "entry_id": entry_id,
+                        "id": job.id,
+                        "priority": job.priority,
+                        "type": payload_type_name(&job.payload),
+                        "attempts": job.attempts,
+                        "created_at": job.created_at,
+                    }));
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `deadpool-redis` as optional dependency in raps-cli (needed for `Pool` type in `ServiceState` struct)
- Fix clippy warnings: `filter_next`, `collapsible_if`, `type_complexity`, `unused_variables`
- Add `StreamEntries` type alias for the complex XREVRANGE result type

## Test plan

- [x] `cargo build --features kubernetes -p raps-cli` — compiles cleanly
- [x] `cargo clippy --features kubernetes -p raps-cli` — no new warnings from serve.rs
- [x] `cargo test --features kubernetes -p raps-cli` — all 124 unit + integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)