### PR TITLE
feat: align Helm templates with raps serve commands and GHCR

### DIFF
--- a/deploy/helm/raps/templates/coordinator-deployment.yaml
+++ b/deploy/helm/raps/templates/coordinator-deployment.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: coordinator
           image: {{ include "raps.image" (dict "image" .Values.coordinator.image "global" .Values.global) }}
+          command:
+            - raps
+            - serve
+            - coordinator
+            - --port
+            - {{ .Values.coordinator.service.port | quote }}
+            - --redis-url
+            - {{ include "raps.redisUrl" . }}
           env:
             - name: RUST_LOG
               valueFrom:

--- a/deploy/helm/raps/templates/dashboard-deployment.yaml
+++ b/deploy/helm/raps/templates/dashboard-deployment.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: dashboard
           image: {{ include "raps.image" (dict "image" .Values.dashboard.image "global" .Values.global) }}
+          command:
+            - raps
+            - serve
+            - dashboard
+            - --port
+            - {{ .Values.dashboard.service.port | quote }}
+            - --redis-url
+            - {{ include "raps.redisUrl" . }}
           env:
             - name: RUST_LOG
               valueFrom:

--- a/deploy/helm/raps/templates/proxy-deployment.yaml
+++ b/deploy/helm/raps/templates/proxy-deployment.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: proxy
           image: {{ include "raps.image" (dict "image" .Values.proxy.image "global" .Values.global) }}
+          command:
+            - raps
+            - serve
+            - proxy
+            - --port
+            - {{ .Values.proxy.service.port | quote }}
+            - --redis-url
+            - {{ include "raps.redisUrl" . }}
           env:
             - name: RUST_LOG
               valueFrom:

--- a/deploy/helm/raps/templates/webhook-deployment.yaml
+++ b/deploy/helm/raps/templates/webhook-deployment.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: webhook
           image: {{ include "raps.image" (dict "image" .Values.webhook.image "global" .Values.global) }}
+          command:
+            - raps
+            - serve
+            - webhook
+            - --port
+            - {{ .Values.webhook.service.port | quote }}
+            - --redis-url
+            - {{ include "raps.redisUrl" . }}
           env:
             - name: RUST_LOG
               valueFrom:

--- a/deploy/helm/raps/tests/coordinator_test.yaml
+++ b/deploy/helm/raps/tests/coordinator_test.yaml
@@ -20,6 +20,20 @@ tests:
           path: spec.replicas
           value: 2
 
+  - it: should have correct command
+    template: templates/coordinator-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - raps
+            - serve
+            - coordinator
+            - --port
+            - "8081"
+            - --redis-url
+            - redis://RELEASE-NAME-redis-master:6379
+
   - it: should use envFrom with aps-credentials secret
     template: templates/coordinator-deployment.yaml
     asserts:

--- a/deploy/helm/raps/tests/cronjob_test.yaml
+++ b/deploy/helm/raps/tests/cronjob_test.yaml
@@ -63,7 +63,7 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "rapscli/raps-worker:5.2.0"
+          value: "ghcr.io/dmytro-yemelianov/raps-worker:5.2.0"
 
   - it: should render multiple CronJobs
     set:

--- a/deploy/helm/raps/tests/dashboard_test.yaml
+++ b/deploy/helm/raps/tests/dashboard_test.yaml
@@ -14,6 +14,20 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should have correct command
+    template: templates/dashboard-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - raps
+            - serve
+            - dashboard
+            - --port
+            - "3000"
+            - --redis-url
+            - redis://RELEASE-NAME-redis-master:6379
+
   - it: should not use envFrom with credentials
     template: templates/dashboard-deployment.yaml
     asserts:

--- a/deploy/helm/raps/tests/helpers_test.yaml
+++ b/deploy/helm/raps/tests/helpers_test.yaml
@@ -80,21 +80,21 @@ tests:
           path: data.RAPS_REDIS_URL
           value: "redis://external-host:6380"
 
-  - it: should render default image without registry
+  - it: should render default image with GHCR registry
     template: templates/proxy-deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "rapscli/raps-proxy:5.2.0"
+          value: "ghcr.io/dmytro-yemelianov/raps-proxy:5.2.0"
 
-  - it: should render image with custom registry
+  - it: should render image with custom registry override
     template: templates/proxy-deployment.yaml
     set:
-      global.image.registry: ghcr.io
+      global.image.registry: custom.registry.io/myorg
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/rapscli/raps-proxy:5.2.0"
+          value: "custom.registry.io/myorg/raps-proxy:5.2.0"
 
   - it: should use namespace override
     template: templates/configmap.yaml

--- a/deploy/helm/raps/tests/proxy_test.yaml
+++ b/deploy/helm/raps/tests/proxy_test.yaml
@@ -25,7 +25,22 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "rapscli/raps-proxy:5.2.0"
+          value: "ghcr.io/dmytro-yemelianov/raps-proxy:5.2.0"
+
+
+  - it: should have correct command
+    template: templates/proxy-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - raps
+            - serve
+            - proxy
+            - --port
+            - "8080"
+            - --redis-url
+            - redis://RELEASE-NAME-redis-master:6379
 
   - it: should have liveness and readiness probes
     template: templates/proxy-deployment.yaml

--- a/deploy/helm/raps/tests/webhook_test.yaml
+++ b/deploy/helm/raps/tests/webhook_test.yaml
@@ -19,7 +19,21 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "rapscli/raps-webhook:5.2.0"
+          value: "ghcr.io/dmytro-yemelianov/raps-webhook:5.2.0"
+
+  - it: should have correct command
+    template: templates/webhook-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - raps
+            - serve
+            - webhook
+            - --port
+            - "9000"
+            - --redis-url
+            - redis://RELEASE-NAME-redis-master:6379
 
   - it: should expose webhook port
     template: templates/webhook-deployment.yaml

--- a/deploy/helm/raps/values.yaml
+++ b/deploy/helm/raps/values.yaml
@@ -1,7 +1,7 @@
 # -- Global configuration
 global:
   image:
-    registry: ""
+    registry: "ghcr.io/dmytro-yemelianov"
     tag: "5.2.0"
   namespace: ""
 
@@ -13,7 +13,7 @@ proxy:
   replicaCount: 2
   image:
     registry: ""
-    repository: rapscli/raps-proxy
+    repository: raps-proxy
     tag: ""
   resources:
     requests:
@@ -39,7 +39,7 @@ workers:
   metricsPort: 9091
   image:
     registry: ""
-    repository: rapscli/raps-worker
+    repository: raps-worker
     tag: ""
   resources:
     requests:
@@ -82,7 +82,7 @@ coordinator:
   replicaCount: 2
   image:
     registry: ""
-    repository: rapscli/raps-coordinator
+    repository: raps-coordinator
     tag: ""
   resources:
     requests:
@@ -99,7 +99,7 @@ coordinator:
 webhook:
   image:
     registry: ""
-    repository: rapscli/raps-webhook
+    repository: raps-webhook
     tag: ""
   resources:
     requests:
@@ -126,7 +126,7 @@ dashboard:
   replicaCount: 1
   image:
     registry: ""
-    repository: rapscli/raps-dashboard
+    repository: raps-dashboard
     tag: ""
   resources:
     requests:


### PR DESCRIPTION
## Summary

- Add explicit `command:` blocks to proxy, coordinator, webhook, and dashboard Helm deployment templates — they now invoke `raps serve <component> --port <port> --redis-url <url>` matching the worker template pattern
- Set `global.image.registry` to `ghcr.io/dmytro-yemelianov` to match the Docker CI workflow (`.github/workflows/docker.yml`) that pushes to GHCR
- Shorten per-service `repository` to just `raps-<component>` (registry prefix comes from global)
- Add 4 new Helm unit tests verifying command block rendering
- Update existing image assertion tests for the new GHCR registry path

## Test plan

- [x] `helm unittest deploy/helm/raps/` — all 115 tests pass (14 suites)
- [x] `helm template raps deploy/helm/raps/` — renders cleanly
- [x] Port values from `values.yaml` correctly propagate to `--port` args

🤖 Generated with [Claude Code](https://claude.com/claude-code)