### PR TITLE
test: add 41 pure function unit tests to raps-cli

### DIFF
--- a/raps-cli/src/commands/api.rs
+++ b/raps-cli/src/commands/api.rs
@@ -704,3 +704,140 @@ fn extract_error_message(value: &Value, status: StatusCode) -> String {
         .unwrap_or("Request failed")
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_key_value_valid() {
+        let result = parse_key_value("key=value").unwrap();
+        assert_eq!(result, ("key".to_string(), "value".to_string()));
+    }
+
+    #[test]
+    fn test_parse_key_value_value_with_equals() {
+        let result = parse_key_value("key=val=ue").unwrap();
+        assert_eq!(result, ("key".to_string(), "val=ue".to_string()));
+    }
+
+    #[test]
+    fn test_parse_key_value_missing_equals() {
+        let result = parse_key_value("noequals");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid format"));
+    }
+
+    #[test]
+    fn test_parse_key_value_empty_value() {
+        let result = parse_key_value("key=").unwrap();
+        assert_eq!(result, ("key".to_string(), "".to_string()));
+    }
+
+    #[test]
+    fn test_parse_header_valid() {
+        let result = parse_header("Content-Type: application/json").unwrap();
+        assert_eq!(
+            result,
+            ("Content-Type".to_string(), "application/json".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_header_no_colon() {
+        let result = parse_header("invalid");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid header format"));
+    }
+
+    #[test]
+    fn test_parse_header_value_with_colon() {
+        let result = parse_header("Auth: Bearer:token").unwrap();
+        assert_eq!(
+            result,
+            ("Auth".to_string(), "Bearer:token".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_url_relative_endpoint() {
+        let url = build_url("https://developer.api.autodesk.com", "/oss/v2/buckets", &[]).unwrap();
+        assert_eq!(url, "https://developer.api.autodesk.com/oss/v2/buckets");
+    }
+
+    #[test]
+    fn test_build_url_absolute_endpoint() {
+        let url = build_url(
+            "https://developer.api.autodesk.com",
+            "https://custom.api.example.com/endpoint",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(url, "https://custom.api.example.com/endpoint");
+    }
+
+    #[test]
+    fn test_build_url_with_query_params() {
+        let params = vec![
+            ("key1".to_string(), "val1".to_string()),
+            ("key2".to_string(), "val2".to_string()),
+        ];
+        let url =
+            build_url("https://developer.api.autodesk.com", "/endpoint", &params).unwrap();
+        assert!(url.contains('?'));
+        assert!(url.contains("key1=val1"));
+        assert!(url.contains("key2=val2"));
+        assert!(url.contains('&'));
+    }
+
+    #[test]
+    fn test_build_url_no_query_params() {
+        let url =
+            build_url("https://developer.api.autodesk.com", "/endpoint", &[]).unwrap();
+        assert!(!url.contains('?'));
+    }
+
+    #[test]
+    fn test_categorize_error_codes() {
+        assert_eq!(categorize_error(401), "authentication");
+        assert_eq!(categorize_error(403), "authentication");
+        assert_eq!(categorize_error(400), "validation");
+        assert_eq!(categorize_error(422), "validation");
+        assert_eq!(categorize_error(404), "not_found");
+        assert_eq!(categorize_error(429), "rate_limited");
+        assert_eq!(categorize_error(500), "server_error");
+        assert_eq!(categorize_error(502), "server_error");
+        assert_eq!(categorize_error(503), "server_error");
+        assert_eq!(categorize_error(599), "server_error");
+        assert_eq!(categorize_error(301), "error");
+    }
+
+    #[test]
+    fn test_extract_error_message_fields() {
+        let status_404 = StatusCode::from_u16(404).unwrap();
+
+        // "message" field takes priority
+        let val = json!({"message": "Not found", "error": "err"});
+        assert_eq!(extract_error_message(&val, status_404), "Not found");
+
+        // Falls back to "error"
+        let val = json!({"error": "Something went wrong"});
+        assert_eq!(
+            extract_error_message(&val, status_404),
+            "Something went wrong"
+        );
+
+        // Falls back to "reason"
+        let val = json!({"reason": "Bad input"});
+        assert_eq!(extract_error_message(&val, status_404), "Bad input");
+
+        // Falls back to "developerMessage"
+        let val = json!({"developerMessage": "Dev hint"});
+        assert_eq!(extract_error_message(&val, status_404), "Dev hint");
+
+        // Falls back to canonical reason
+        let val = json!({"other": "field"});
+        assert_eq!(extract_error_message(&val, status_404), "Not Found");
+    }
+}

--- a/raps-cli/src/commands/auth.rs
+++ b/raps-cli/src/commands/auth.rs
@@ -735,3 +735,86 @@ async fn inspect_token(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_mask_string_long() {
+        // 16 chars → "abcd...mnop"
+        let result = mask_string("abcdefghijklmnop");
+        assert_eq!(result, "abcd...mnop");
+    }
+
+    #[test]
+    fn test_mask_string_short() {
+        // 5 chars → "*****"
+        let result = mask_string("hello");
+        assert_eq!(result, "*****");
+    }
+
+    #[test]
+    fn test_mask_string_exactly_8() {
+        // 8 chars → "********"
+        let result = mask_string("12345678");
+        assert_eq!(result, "********");
+    }
+
+    #[test]
+    fn test_mask_string_9_chars() {
+        // 9 chars → first4...last4
+        let result = mask_string("123456789");
+        assert_eq!(result, "1234...6789");
+    }
+
+    #[test]
+    fn test_mask_string_empty() {
+        let result = mask_string("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_login_preset_all_scopes() {
+        let scopes = LoginPreset::All.scopes();
+        assert_eq!(scopes.len(), AVAILABLE_SCOPES.len());
+        for (scope, _) in AVAILABLE_SCOPES {
+            assert!(scopes.contains(scope), "Missing scope: {}", scope);
+        }
+    }
+
+    #[test]
+    fn test_login_preset_viewer_readonly() {
+        let scopes = LoginPreset::Viewer.scopes();
+        for scope in &scopes {
+            assert!(
+                scope.ends_with(":read") || scope.ends_with(":search"),
+                "Viewer scope '{}' is not read-only",
+                scope
+            );
+        }
+    }
+
+    #[test]
+    fn test_login_preset_no_duplicates() {
+        let presets = [
+            LoginPreset::All,
+            LoginPreset::Viewer,
+            LoginPreset::Editor,
+            LoginPreset::Storage,
+            LoginPreset::Automation,
+            LoginPreset::Admin,
+        ];
+        for preset in &presets {
+            let scopes = preset.scopes();
+            let unique: HashSet<&&str> = scopes.iter().collect();
+            assert_eq!(
+                scopes.len(),
+                unique.len(),
+                "Duplicate scopes found in preset {:?}",
+                preset
+            );
+        }
+    }
+}

--- a/raps-cli/src/commands/bucket.rs
+++ b/raps-cli/src/commands/bucket.rs
@@ -562,3 +562,77 @@ fn chrono_humanize(timestamp_ms: u64) -> String {
         "in the future".to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
+
+    #[test]
+    fn test_chrono_humanize_seconds() {
+        let ts = now_ms() - 30_000; // 30 seconds ago
+        let result = chrono_humanize(ts);
+        assert!(
+            result.contains("seconds ago"),
+            "Expected 'seconds ago', got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_chrono_humanize_minutes() {
+        let ts = now_ms() - 120_000; // 2 minutes ago
+        let result = chrono_humanize(ts);
+        assert!(
+            result.contains("minutes ago"),
+            "Expected 'minutes ago', got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_chrono_humanize_hours() {
+        let ts = now_ms() - 10_800_000; // 3 hours ago
+        let result = chrono_humanize(ts);
+        assert!(
+            result.contains("hours ago"),
+            "Expected 'hours ago', got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_chrono_humanize_days() {
+        let ts = now_ms() - 172_800_000; // 2 days ago
+        let result = chrono_humanize(ts);
+        assert!(
+            result.contains("days ago"),
+            "Expected 'days ago', got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_chrono_humanize_future() {
+        let ts = now_ms() + 60_000_000; // far in the future
+        let result = chrono_humanize(ts);
+        assert_eq!(result, "in the future");
+    }
+
+    #[test]
+    fn test_chrono_humanize_epoch() {
+        let result = chrono_humanize(0);
+        assert!(
+            result.contains("days ago"),
+            "Expected 'days ago' for epoch, got: {}",
+            result
+        );
+    }
+}

--- a/raps-cli/src/commands/object/mod.rs
+++ b/raps-cli/src/commands/object/mod.rs
@@ -334,3 +334,52 @@ pub(super) fn truncate_str(s: &str, max_len: usize) -> String {
         format!("{}...", &s[..max_len - 3])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_size_bytes() {
+        assert_eq!(format_size(512), "512 B");
+    }
+
+    #[test]
+    fn test_format_size_kilobytes() {
+        assert_eq!(format_size(1024), "1.00 KB");
+    }
+
+    #[test]
+    fn test_format_size_megabytes() {
+        assert_eq!(format_size(1_048_576), "1.00 MB");
+    }
+
+    #[test]
+    fn test_format_size_gigabytes() {
+        assert_eq!(format_size(1_073_741_824), "1.00 GB");
+    }
+
+    #[test]
+    fn test_format_size_zero() {
+        assert_eq!(format_size(0), "0 B");
+    }
+
+    #[test]
+    fn test_format_size_boundary() {
+        assert_eq!(format_size(1023), "1023 B");
+        assert_eq!(format_size(1024), "1.00 KB");
+    }
+
+    #[test]
+    fn test_truncate_str_short() {
+        let result = truncate_str("hello", 10);
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_truncate_str_long() {
+        let result = truncate_str("this is a very long string", 10);
+        assert_eq!(result, "this is...");
+        assert_eq!(result.len(), 10);
+    }
+}

--- a/raps-cli/src/commands/webhook.rs
+++ b/raps-cli/src/commands/webhook.rs
@@ -916,3 +916,60 @@ async fn webhook_drain(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_str_exact_max() {
+        let result = truncate_str("hello", 5);
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_truncate_str_over_max() {
+        let result = truncate_str("this is a long string", 10);
+        assert_eq!(result, "this is...");
+        assert_eq!(result.len(), 10);
+    }
+
+    #[test]
+    fn test_truncate_str_empty() {
+        let result = truncate_str("", 10);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_truncate_str_small_max() {
+        let result = truncate_str("abcdefgh", 4);
+        assert_eq!(result, "a...");
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn test_webhook_list_output_serialization() {
+        let output = WebhookListOutput {
+            hook_id: "hook-123".to_string(),
+            event: "dm.version.added".to_string(),
+            callback_url: "https://example.com/webhook".to_string(),
+            status: "active".to_string(),
+        };
+        let json = serde_json::to_value(&output).unwrap();
+        assert_eq!(json["hook_id"], "hook-123");
+        assert_eq!(json["event"], "dm.version.added");
+        assert_eq!(json["callback_url"], "https://example.com/webhook");
+        assert_eq!(json["status"], "active");
+    }
+
+    #[test]
+    fn test_verify_signature_output_serialization() {
+        let output = VerifySignatureOutput {
+            valid: true,
+            message: "Signature verified".to_string(),
+        };
+        let json = serde_json::to_value(&output).unwrap();
+        assert_eq!(json["valid"], true);
+        assert_eq!(json["message"], "Signature verified");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 41 unit tests across 5 raps-cli command modules that previously had 0 tests
- Targets pure functions only (no async runtime or network mocking needed)
- Phase 3 of test coverage sprint: raps-cli unit test count 168 → 209

### Test breakdown
| File | Tests | Functions covered |
|------|-------|-------------------|
| `api.rs` | 13 | `parse_key_value`, `parse_header`, `build_url`, `categorize_error`, `extract_error_message` |
| `auth.rs` | 8 | `mask_string`, `LoginPreset::scopes` |
| `object/mod.rs` | 8 | `format_size`, `truncate_str` |
| `bucket.rs` | 6 | `chrono_humanize` |
| `webhook.rs` | 6 | `truncate_str`, output type serialization |

## Test plan
- [x] `cargo test -p raps-cli` — 209 passed, 0 failed
- [x] All 41 new tests pass individually
- [x] No regressions in existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)