### PR TITLE
Harden webhook verification and pipeline/runtime edge cases

### DIFF
--- a/raps-cli/src/commands/pipeline.rs
+++ b/raps-cli/src/commands/pipeline.rs
@@ -33,6 +33,10 @@ pub enum PipelineCommands {
         /// Dry run (show commands without executing)
         #[arg(short, long)]
         dry_run: bool,
+
+        /// Pipeline variable override (KEY=VALUE, repeatable)
+        #[arg(long = "var", value_parser = parse_var_assignment)]
+        var: Vec<(String, String)>,
     },
 
     /// Validate a pipeline file
@@ -184,7 +188,8 @@ impl PipelineCommands {
                 file,
                 ignore_failure,
                 dry_run,
-            } => run_pipeline(&file, ignore_failure, dry_run, output_format).await,
+                var,
+            } => run_pipeline(&file, ignore_failure, dry_run, var, output_format).await,
             PipelineCommands::Validate { file } => validate_pipeline(&file, output_format).await,
             PipelineCommands::Sample { out_file } => generate_sample(&out_file, output_format),
             PipelineCommands::Create {
@@ -567,9 +572,11 @@ async fn run_pipeline(
     file: &PathBuf,
     global_ignore_failure: bool,
     dry_run: bool,
+    var_overrides: Vec<(String, String)>,
     output_format: OutputFormat,
 ) -> Result<()> {
-    let pipeline = load_pipeline(file).await?;
+    let mut pipeline = load_pipeline(file).await?;
+    apply_variable_overrides(&mut pipeline.variables, &var_overrides);
     let context: StepContext = Arc::new(Mutex::new(HashMap::new()));
 
     if output_format.supports_colors() {
@@ -677,6 +684,30 @@ async fn run_pipeline(
     Ok(())
 }
 
+fn parse_var_assignment(s: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = s.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid variable assignment '{}'. Expected KEY=VALUE",
+            s
+        ));
+    }
+    let key = parts[0].trim();
+    if key.is_empty() {
+        return Err("Variable key cannot be empty".to_string());
+    }
+    Ok((key.to_string(), parts[1].to_string()))
+}
+
+fn apply_variable_overrides(
+    base: &mut HashMap<String, String>,
+    overrides: &[(String, String)],
+) {
+    for (key, value) in overrides {
+        base.insert(key.clone(), value.clone());
+    }
+}
+
 fn execute_raps_command(command: &str) -> Result<i32> {
     // Get the current executable path
     let exe_path = std::env::current_exe().context("Failed to get current executable path")?;
@@ -728,16 +759,17 @@ fn eval_expression(expr: &str, context: &StepContext) -> Result<bool> {
 }
 
 fn eval_comparison(expr: &str, context: &StepContext) -> Result<bool> {
+    // Support: <left> || <right>
+    // Parse OR first so AND has higher precedence.
+    if let Some((left, right)) = expr.split_once("||") {
+        return Ok(
+            eval_comparison(left.trim(), context)? || eval_comparison(right.trim(), context)?
+        );
+    }
     // Support: <left> && <right>
     if let Some((left, right)) = expr.split_once("&&") {
         return Ok(
             eval_comparison(left.trim(), context)? && eval_comparison(right.trim(), context)?
-        );
-    }
-    // Support: <left> || <right>
-    if let Some((left, right)) = expr.split_once("||") {
-        return Ok(
-            eval_comparison(left.trim(), context)? || eval_comparison(right.trim(), context)?
         );
     }
 
@@ -1601,6 +1633,58 @@ steps:
         assert_eq!(parse_duration("1h").unwrap(), std::time::Duration::from_secs(3600));
         assert!(parse_duration("5d").is_err());
         assert!(parse_duration("  ").is_err());
+    }
+
+    #[test]
+    fn test_eval_expr_operator_precedence_and_over_or() {
+        let mut ctx = HashMap::new();
+        ctx.insert("a".to_string(), StepResult { exit_code: 0 }); // true
+        ctx.insert("b".to_string(), StepResult { exit_code: 1 }); // false
+        ctx.insert("c".to_string(), StepResult { exit_code: 1 }); // false
+        let ctx = Arc::new(Mutex::new(ctx));
+
+        // Should evaluate as: true || (false && false) == true
+        assert!(eval_expression(
+            "${{ steps.a.exit_code == 0 || steps.b.exit_code == 0 && steps.c.exit_code == 0 }}",
+            &ctx
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn test_parse_var_assignment_valid() {
+        let parsed = parse_var_assignment("BUCKET=my-bucket").unwrap();
+        assert_eq!(parsed, ("BUCKET".to_string(), "my-bucket".to_string()));
+    }
+
+    #[test]
+    fn test_parse_var_assignment_value_with_equals() {
+        let parsed = parse_var_assignment("TOKEN=abc=def").unwrap();
+        assert_eq!(parsed, ("TOKEN".to_string(), "abc=def".to_string()));
+    }
+
+    #[test]
+    fn test_parse_var_assignment_invalid() {
+        assert!(parse_var_assignment("missing_equals").is_err());
+        assert!(parse_var_assignment("=value").is_err());
+    }
+
+    #[test]
+    fn test_apply_variable_overrides_cli_wins() {
+        let mut vars = HashMap::from([
+            ("BUCKET".to_string(), "from-file".to_string()),
+            ("REGION".to_string(), "US".to_string()),
+        ]);
+        let overrides = vec![
+            ("BUCKET".to_string(), "from-cli".to_string()),
+            ("MODEL".to_string(), "test.rvt".to_string()),
+        ];
+
+        apply_variable_overrides(&mut vars, &overrides);
+
+        assert_eq!(vars.get("BUCKET"), Some(&"from-cli".to_string()));
+        assert_eq!(vars.get("REGION"), Some(&"US".to_string()));
+        assert_eq!(vars.get("MODEL"), Some(&"test.rvt".to_string()));
     }
 }
 

--- a/raps-cli/src/commands/serve.rs
+++ b/raps-cli/src/commands/serve.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::{
+    body::Bytes,
     Json, Router,
     extract::{Path, State},
     http::{HeaderMap, Method, StatusCode, Uri},
@@ -654,20 +655,19 @@ struct WebhookEvent {
 async fn webhook_callback(
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(event): Json<WebhookEvent>,
+    body: Bytes,
 ) -> impl IntoResponse {
     // Verify signature if APS_WEBHOOK_SECRET is set
     let secret = std::env::var("APS_WEBHOOK_SECRET").ok();
     if let Some(ref secret) = secret {
         let signature = headers
-            .get("x-adsk-signature")
+            .get("x-aps-signature")
+            .or_else(|| headers.get("x-adsk-signature"))
             .and_then(|v| v.to_str().ok());
         match signature {
             Some(sig) => {
                 // Verify HMAC-SHA256 signature
-                let body_bytes =
-                    serde_json::to_vec(&event.payload).unwrap_or_default();
-                if !verify_webhook_signature(secret, &body_bytes, sig) {
+                if !verify_webhook_signature(secret, body.as_ref(), sig) {
                     tracing::warn!("Webhook signature verification failed");
                     return (
                         StatusCode::UNAUTHORIZED,
@@ -677,7 +677,7 @@ async fn webhook_callback(
                 }
             }
             None => {
-                tracing::warn!("Webhook request missing x-adsk-signature header");
+                tracing::warn!("Webhook request missing signature header");
                 return (
                     StatusCode::UNAUTHORIZED,
                     Json(serde_json::json!({"error": "missing signature"})),
@@ -686,6 +686,17 @@ async fn webhook_callback(
             }
         }
     }
+
+    let event: WebhookEvent = match serde_json::from_slice(body.as_ref()) {
+        Ok(evt) => evt,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid JSON payload"})),
+            )
+                .into_response();
+        }
+    };
 
     // Publish event to Redis Stream
     let event_type = event
@@ -741,8 +752,8 @@ async fn webhook_callback(
 }
 
 fn verify_webhook_signature(secret: &str, body: &[u8], expected_signature: &str) -> bool {
-    use sha2::Sha256;
     use hmac::{Hmac, Mac};
+    use sha2::Sha256;
 
     type HmacSha256 = Hmac<Sha256>;
 
@@ -751,8 +762,11 @@ fn verify_webhook_signature(secret: &str, body: &[u8], expected_signature: &str)
     };
     mac.update(body);
 
-    // The signature may be hex-encoded
-    let Ok(expected_bytes) = hex::decode(expected_signature) else {
+    let normalized = expected_signature.trim();
+    let normalized = normalized.strip_prefix("sha256=").unwrap_or(normalized);
+
+    // APS webhook signatures are hex-encoded HMAC-SHA256 digests.
+    let Ok(expected_bytes) = hex::decode(normalized) else {
         return false;
     };
 

--- a/raps-cli/src/commands/webhook.rs
+++ b/raps-cli/src/commands/webhook.rs
@@ -93,7 +93,7 @@ pub enum WebhookCommands {
     VerifySignature {
         /// The webhook payload (JSON string or @file)
         payload: String,
-        /// The signature from X-Adsk-Signature header
+        /// The signature from x-aps-signature (or legacy x-adsk-signature)
         #[arg(short, long)]
         signature: String,
         /// The webhook secret
@@ -710,7 +710,7 @@ struct VerifySignatureOutput {
 fn verify_signature(
     payload: &str,
     signature: &str,
-    _secret: &str,
+    secret: &str,
     output_format: OutputFormat,
 ) -> Result<()> {
     use std::io::Read;
@@ -726,23 +726,17 @@ fn verify_signature(
         payload.to_string()
     };
 
-    // Calculate HMAC-SHA256 signature
-    // Note: In a real implementation, you'd use a crypto library like hmac + sha2
-    // For now, we'll provide a placeholder that shows the expected format
+    let valid = verify_hmac_sha256_signature(secret, payload_data.as_bytes(), signature);
 
-    // The APS webhook signature format is typically base64(HMAC-SHA256(secret, payload))
-    // This is a simplified verification that checks format
-    let is_valid_format = signature.len() > 20 && !signature.contains(' ');
-
-    let output = if is_valid_format {
+    let output = if valid {
         VerifySignatureOutput {
             valid: true,
-            message: "Signature format is valid. For full cryptographic verification, ensure your webhook handler validates using HMAC-SHA256.".to_string(),
+            message: "Signature is valid (HMAC-SHA256)".to_string(),
         }
     } else {
         VerifySignatureOutput {
             valid: false,
-            message: "Signature format appears invalid".to_string(),
+            message: "Signature is invalid".to_string(),
         }
     };
 
@@ -768,6 +762,27 @@ fn verify_signature(
     }
 
     Ok(())
+}
+
+fn verify_hmac_sha256_signature(secret: &str, body: &[u8], signature: &str) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(body);
+
+    let normalized = signature.trim();
+    let normalized = normalized.strip_prefix("sha256=").unwrap_or(normalized);
+
+    let Ok(expected_bytes) = hex::decode(normalized) else {
+        return false;
+    };
+
+    mac.verify_slice(&expected_bytes).is_ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -971,5 +986,42 @@ mod tests {
         let json = serde_json::to_value(&output).unwrap();
         assert_eq!(json["valid"], true);
         assert_eq!(json["message"], "Signature verified");
+    }
+
+    #[test]
+    fn test_verify_hmac_sha256_signature_valid() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let secret = "test-secret";
+        let body = br#"{"event":"dm.version.added"}"#;
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let sig = hex::encode(mac.finalize().into_bytes());
+
+        assert!(verify_hmac_sha256_signature(secret, body, &sig));
+    }
+
+    #[test]
+    fn test_verify_hmac_sha256_signature_sha256_prefix() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let secret = "test-secret";
+        let body = b"payload";
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let sig = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+        assert!(verify_hmac_sha256_signature(secret, body, &sig));
+    }
+
+    #[test]
+    fn test_verify_hmac_sha256_signature_invalid() {
+        assert!(!verify_hmac_sha256_signature(
+            "secret",
+            b"payload",
+            "not-a-valid-signature"
+        ));
     }
 }

--- a/raps-cli/src/plugins.rs
+++ b/raps-cli/src/plugins.rs
@@ -186,6 +186,10 @@ pub struct PluginManager {
 }
 
 impl PluginManager {
+    fn load_latest_config(&self) -> PluginConfig {
+        PluginConfig::load().unwrap_or_else(|_| self.config.clone())
+    }
+
     /// Create a new plugin manager
     pub fn new() -> Result<Self> {
         let config = PluginConfig::load().unwrap_or_default();
@@ -267,8 +271,10 @@ impl PluginManager {
 
     /// Execute a plugin by name
     pub fn execute_plugin(&self, name: &str, args: &[&str]) -> Result<i32> {
+        let config = self.load_latest_config();
+
         // Check configured plugins first
-        if let Some(entry) = self.config.plugins.get(name) {
+        if let Some(entry) = config.plugins.get(name) {
             if !entry.enabled {
                 anyhow::bail!("Plugin '{name}' is disabled");
             }
@@ -305,8 +311,9 @@ impl PluginManager {
     /// - If signature + public_key present: verify ed25519 signature
     fn verify_plugin_integrity(&self, name: &str, path: &Path) -> Result<()> {
         let current_hash = compute_binary_hash(path)?;
+        let config = self.load_latest_config();
 
-        if let Some(entry) = self.config.plugins.get(name) {
+        if let Some(entry) = config.plugins.get(name) {
             // Check ed25519 signature if present
             if let (Some(sig_hex), Some(key_hex)) = (&entry.signature, &entry.public_key) {
                 verify_ed25519_signature(path, sig_hex, key_hex).with_context(|| {
@@ -391,8 +398,9 @@ impl PluginManager {
     pub fn verify_plugin(&self, name: &str) -> Result<PluginVerifyResult> {
         let path = self.resolve_plugin_path(name)?;
         let current_hash = compute_binary_hash(&path)?;
+        let config = self.load_latest_config();
 
-        if let Some(entry) = self.config.plugins.get(name) {
+        if let Some(entry) = config.plugins.get(name) {
             let hash_match = entry.sha256.as_ref() == Some(&current_hash);
 
             // Check signature
@@ -437,7 +445,9 @@ impl PluginManager {
 
     /// Resolve a plugin name to its filesystem path
     fn resolve_plugin_path(&self, name: &str) -> Result<PathBuf> {
-        if let Some(entry) = self.config.plugins.get(name)
+        let config = self.load_latest_config();
+
+        if let Some(entry) = config.plugins.get(name)
             && let Some(ref path) = entry.path
         {
             return Ok(PathBuf::from(path));

--- a/raps-derivative/src/download.rs
+++ b/raps-derivative/src/download.rs
@@ -5,13 +5,27 @@
 
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 use crate::DerivativeClient;
 
 impl DerivativeClient {
+    fn normalize_lexical_path(path: &Path) -> PathBuf {
+        let mut normalized = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    normalized.pop();
+                }
+                other => normalized.push(other.as_os_str()),
+            }
+        }
+        normalized
+    }
+
     /// Download a derivative to a local file
     pub async fn download_derivative(
         &self,
@@ -56,16 +70,25 @@ impl DerivativeClient {
             .unwrap_or("derivative");
         pb.set_message(format!("Downloading {}", filename));
 
-        // Validate output path stays within current directory
-        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        if let (Ok(canon_cwd), Ok(canon_target)) = (cwd.canonicalize(), output_path.canonicalize())
-            && !canon_target.starts_with(&canon_cwd)
-        {
-            anyhow::bail!(
-                "Path '{}' escapes working directory '{}'",
-                output_path.display(),
-                cwd.display()
-            );
+        // Validate output path stays within current directory, even if the file does not exist yet.
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let canon_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        let abs_output = if output_path.is_absolute() {
+            output_path.to_path_buf()
+        } else {
+            cwd.join(output_path)
+        };
+        if let Some(parent) = abs_output.parent() {
+            let checked_parent = parent
+                .canonicalize()
+                .unwrap_or_else(|_| Self::normalize_lexical_path(parent));
+            if !checked_parent.starts_with(&canon_cwd) {
+                anyhow::bail!(
+                    "Path '{}' escapes working directory '{}'",
+                    output_path.display(),
+                    cwd.display()
+                );
+            }
         }
 
         // Create parent directories if needed

--- a/raps-kernel/src/storage.rs
+++ b/raps-kernel/src/storage.rs
@@ -226,7 +226,7 @@ impl TokenStorage {
             Ok(e) => e,
             Err(e) => {
                 // If keyring is not available, fall back to file storage
-                tracing::warn!(error = %e, "Keychain not available, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_STORAGE_BACKEND=file");
+                tracing::warn!(error = %e, "Keychain not available, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_USE_FILE_STORAGE=true");
                 return self.save_file(token);
             }
         };
@@ -235,7 +235,7 @@ impl TokenStorage {
             Ok(()) => Ok(()),
             Err(e) => {
                 // If keychain save fails, fall back to file storage
-                tracing::warn!(error = %e, "Keychain save failed, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_STORAGE_BACKEND=file");
+                tracing::warn!(error = %e, "Keychain save failed, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_USE_FILE_STORAGE=true");
                 self.save_file(token)
             }
         }
@@ -246,7 +246,7 @@ impl TokenStorage {
         let entry = match keyring::Entry::new(&self.service_name, &self.username) {
             Ok(e) => e,
             Err(e) => {
-                tracing::warn!(error = %e, "Keychain not available, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_STORAGE_BACKEND=file");
+                tracing::warn!(error = %e, "Keychain not available, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_USE_FILE_STORAGE=true");
                 return self.load_file();
             }
         };
@@ -262,7 +262,7 @@ impl TokenStorage {
                 self.load_file()
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Keychain load failed, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_STORAGE_BACKEND=file");
+                tracing::warn!(error = %e, "Keychain load failed, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_USE_FILE_STORAGE=true");
                 self.load_file()
             }
         }
@@ -290,7 +290,7 @@ impl TokenStorage {
             }
             Err(e) => {
                 // If keychain delete fails, try file storage
-                tracing::warn!(error = %e, "Keychain delete failed, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_STORAGE_BACKEND=file");
+                tracing::warn!(error = %e, "Keychain delete failed, using file storage instead. This is normal on headless servers and CI/CD. To silence this, set RAPS_USE_FILE_STORAGE=true");
                 self.delete_file()
             }
         }

--- a/raps-oss/src/objects.rs
+++ b/raps-oss/src/objects.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
@@ -15,6 +15,20 @@ use crate::OssClient;
 use crate::types::*;
 
 impl OssClient {
+    fn normalize_lexical_path(path: &Path) -> PathBuf {
+        let mut normalized = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    normalized.pop();
+                }
+                other => normalized.push(other.as_os_str()),
+            }
+        }
+        normalized
+    }
+
     /// Upload a file to a bucket using S3 signed URLs
     /// Automatically uses multipart upload for files larger than 5MB
     pub async fn upload_object(
@@ -166,16 +180,25 @@ impl OssClient {
         // Create progress bar (hidden in non-interactive mode)
         let pb = progress::file_progress(total_size, &format!("Downloading {}", object_key));
 
-        // Validate output path stays within current directory
+        // Validate output path stays within current directory, even if the file does not exist yet.
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        if let (Ok(canon_cwd), Ok(canon_target)) = (cwd.canonicalize(), output_path.canonicalize())
-            && !canon_target.starts_with(&canon_cwd)
-        {
-            anyhow::bail!(
-                "Path '{}' escapes working directory '{}'",
-                output_path.display(),
-                cwd.display()
-            );
+        let canon_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        let abs_output = if output_path.is_absolute() {
+            output_path.to_path_buf()
+        } else {
+            cwd.join(output_path)
+        };
+        if let Some(parent) = abs_output.parent() {
+            let checked_parent = parent
+                .canonicalize()
+                .unwrap_or_else(|_| Self::normalize_lexical_path(parent));
+            if !checked_parent.starts_with(&canon_cwd) {
+                anyhow::bail!(
+                    "Path '{}' escapes working directory '{}'",
+                    output_path.display(),
+                    cwd.display()
+                );
+            }
         }
 
         // Stream download


### PR DESCRIPTION
## Summary
- replace webhook placeholder checks with real HMAC-SHA256 signature verification in CLI and local webhook server
- support optional `sha256=` signature prefix and verify server signatures against raw request bytes
- add `pipeline run --var KEY=VALUE` overrides to match MCP tool behavior
- fix download path confinement checks for non-existent output files
- correct expression precedence so `&&` binds tighter than `||`
- reload latest plugin config before integrity checks and execution
- update storage warning guidance to use `RAPS_USE_FILE_STORAGE=true`

## Validation
- `cargo test -p raps-cli --lib`
- `cargo test -p raps-cli --features kubernetes test_verify_webhook_signature`
- `cargo test -p raps-kernel storage::tests::`
- `cargo test -p raps-oss --lib -- --skip integration_tests`
- `cargo test -p raps-derivative --lib -- --skip integration_tests`
- `cargo test --workspace --all-targets`
