### PR TITLE
feat(translate): --watch flag for end-to-end translation workflow

### DIFF
--- a/raps-cli/src/commands/translate/mod.rs
+++ b/raps-cli/src/commands/translate/mod.rs
@@ -9,6 +9,7 @@
 mod metadata;
 mod presets;
 mod translations;
+mod watch;
 
 use anyhow::Result;
 use clap::Subcommand;
@@ -35,6 +36,18 @@ pub enum TranslateCommands {
         /// Wait for translation to complete (polls until done)
         #[arg(short, long)]
         wait: bool,
+
+        /// Watch translation until complete, polling every --poll-interval seconds
+        #[arg(long)]
+        watch: bool,
+
+        /// Polling interval in seconds when using --watch (default: 5)
+        #[arg(long, default_value = "5")]
+        poll_interval: u64,
+
+        /// Timeout in seconds for --watch (0 = no timeout, default: 1800)
+        #[arg(long, default_value = "1800")]
+        watch_timeout: u64,
 
         /// APS data center region (US, EMEA, AUS, CAN, DEU, IND, JPN, GBR)
         #[arg(long, default_value = "US")]
@@ -236,6 +249,9 @@ impl TranslateCommands {
                 format,
                 root_filename,
                 wait,
+                watch,
+                poll_interval,
+                watch_timeout,
                 region,
                 force,
                 serverless,
@@ -260,6 +276,9 @@ impl TranslateCommands {
                         format,
                         root_filename,
                         wait,
+                        watch,
+                        poll_interval,
+                        watch_timeout,
                         output_format,
                         region,
                         force,

--- a/raps-cli/src/commands/translate/translations.rs
+++ b/raps-cli/src/commands/translate/translations.rs
@@ -65,6 +65,9 @@ pub(super) async fn start_translation(
     format: Option<String>,
     root_filename: Option<String>,
     wait: bool,
+    watch: bool,
+    poll_interval: u64,
+    watch_timeout: u64,
     output_format: OutputFormat,
     region_str: String,
     force: bool,
@@ -177,6 +180,18 @@ pub(super) async fn start_translation(
     if wait {
         let urn_for_status = response.urn.clone();
         check_status(client, &urn_for_status, true, output_format).await?;
+    }
+
+    // If --watch flag is set, use the dedicated watch loop with configurable interval/timeout
+    if watch && !wait {
+        super::watch::watch_translation(
+            client,
+            &response.urn,
+            poll_interval,
+            watch_timeout,
+            &output_format,
+        )
+        .await?;
     }
 
     Ok(())

--- a/raps-cli/src/commands/translate/watch.rs
+++ b/raps-cli/src/commands/translate/watch.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 Dmytro Yemelianov
+
+//! Watch mode for translation jobs: polls until complete.
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::output::OutputFormat;
+use raps_derivative::DerivativeClient;
+use raps_kernel::progress;
+
+/// Poll a translation job until it reaches a terminal state.
+///
+/// Displays a spinner while waiting. On success prints a confirmation line;
+/// on failure returns an error so the caller can propagate it.
+///
+/// * `poll_interval` – seconds between status checks
+/// * `timeout_secs`  – maximum seconds to wait; 0 means no timeout
+pub async fn watch_translation(
+    client: &DerivativeClient,
+    urn: &str,
+    poll_interval: u64,
+    timeout_secs: u64,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let deadline = if timeout_secs > 0 {
+        Some(Instant::now() + Duration::from_secs(timeout_secs))
+    } else {
+        None
+    };
+
+    let spinner = progress::spinner("Waiting for translation...");
+
+    loop {
+        if let Some(dl) = deadline {
+            if Instant::now() > dl {
+                spinner.finish_with_message(format!(
+                    "{} Timed out after {}s",
+                    "\u{23F1}".yellow().bold(),
+                    timeout_secs
+                ));
+                anyhow::bail!("Translation watch timed out after {}s", timeout_secs);
+            }
+        }
+
+        let (status, progress_msg) = client.get_status(urn).await?;
+
+        spinner.set_message(format!(
+            "Translating... status={} progress={}",
+            status, progress_msg
+        ));
+
+        match status.as_str() {
+            "success" => {
+                spinner.finish_with_message(format!(
+                    "{} Translation complete! ({})",
+                    "\u{2713}".green().bold(),
+                    progress_msg
+                ));
+                if output_format.supports_colors() {
+                    println!("{} Translation succeeded", "\u{2713}".green().bold());
+                }
+                return Ok(());
+            }
+            "failed" | "timeout" => {
+                spinner.finish_with_message(format!(
+                    "{} Translation {}",
+                    "X".red().bold(),
+                    status
+                ));
+                anyhow::bail!("Translation failed with status: {}", status);
+            }
+            _ => {
+                tokio::time::sleep(Duration::from_secs(poll_interval)).await;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `--watch` flag to `raps translate start` to poll translation status until complete
- Spinner displays live status and progress percentage
- Configurable `--poll-interval` (default 5s) and `--watch-timeout` (default 1800s)
- Exits non-zero on failure or timeout

## Usage
```bash
# Submit and watch until done
raps translate start --urn <urn> --output-format svf2 --watch

# Custom polling interval and 10-minute timeout
raps translate start --urn <urn> --output-format svf2 --watch --poll-interval 10 --watch-timeout 600

# No timeout
raps translate start --urn <urn> --output-format svf2 --watch --watch-timeout 0
```

## Output while watching
```
⠋ Translating... status=inprogress progress=42%
✓ Translation complete!
```

## Test plan
- [ ] `--watch` polls until `success` and exits 0
- [ ] `--watch` exits non-zero when translation fails
- [ ] `--watch-timeout` causes exit after deadline
- [ ] `--poll-interval` controls cadence
- [ ] Without `--watch`, behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)