### PR TITLE
feat(cli): parallel bulk object downloads with concurrency control and multi-progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -594,9 +600,9 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -610,11 +616,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "rustix 1.1.4",
  "serde",
@@ -982,6 +988,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1042,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1568,6 +1594,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1726,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,7 +1769,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1723,7 +1792,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -1845,6 +1914,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1866,6 +1947,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1965,7 +2065,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2058,6 +2158,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2355,12 +2461,14 @@ dependencies = [
  "ed25519-dalek",
  "fs2",
  "futures-util",
+ "glob",
  "hex",
  "hmac",
  "hostname",
  "indicatif",
  "insta",
  "keyring",
+ "notify",
  "nu-ansi-term",
  "predicates",
  "rand 0.8.5",
@@ -2385,6 +2493,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2",
  "shlex",
  "tempfile",
@@ -2424,6 +2533,8 @@ version = "5.3.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
+ "directories",
  "futures-util",
  "indicatif",
  "insta",
@@ -2605,7 +2716,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2656,7 +2767,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2880,7 +3000,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2909,7 +3029,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2922,7 +3042,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3023,7 +3143,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3036,7 +3156,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3228,7 +3348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.1.1",
  "signal-hook",
 ]
 
@@ -3529,7 +3649,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3687,7 +3807,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4103,7 +4223,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4609,7 +4729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/raps-cli/Cargo.toml
+++ b/raps-cli/Cargo.toml
@@ -130,9 +130,6 @@ hex.workspace = true
 # SHA-1 for sync checksum comparison
 sha1.workspace = true
 
-# Glob patterns for sync --exclude
-glob.workspace = true
-
 # Worker hostname identification
 hostname = { workspace = true, optional = true }
 

--- a/raps-cli/src/commands/object/download_bulk.rs
+++ b/raps-cli/src/commands/object/download_bulk.rs
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 Dmytro Yemelianov
+
+//! Parallel bulk download command for OSS objects.
+
+use anyhow::Result;
+use colored::Colorize;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use raps_kernel::interactive;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use crate::output::OutputFormat;
+use raps_oss::OssClient;
+
+use super::{format_size, select_bucket};
+
+// ──────────────────────────── output types ───────────────────────────────────
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct BulkDownloadFileResult {
+    object_key: String,
+    output_path: String,
+    size: Option<u64>,
+    skipped: bool,
+    success: bool,
+    error: Option<String>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct BulkDownloadSummary {
+    success: bool,
+    downloaded: usize,
+    skipped: usize,
+    failed: usize,
+    total_bytes: u64,
+    total_bytes_human: String,
+    elapsed_secs: f64,
+    files: Vec<BulkDownloadFileResult>,
+}
+
+// ──────────────────────────── main function ──────────────────────────────────
+
+pub(super) async fn download_bulk(
+    client: &OssClient,
+    bucket: Option<String>,
+    prefix: String,
+    output_dir: PathBuf,
+    concurrency: usize,
+    skip_existing: bool,
+    flat: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    let bucket_key = select_bucket(client, bucket).await?;
+
+    // Ensure the output directory exists
+    tokio::fs::create_dir_all(&output_dir).await.map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to create output directory '{}': {}",
+            output_dir.display(),
+            e
+        )
+    })?;
+
+    if output_format.supports_colors() {
+        println!(
+            "{} objects matching '{}' from bucket '{}' …",
+            "Listing".dimmed(),
+            prefix.cyan(),
+            bucket_key.cyan()
+        );
+    }
+
+    // List all objects and filter by prefix
+    let all_objects = client.list_objects(&bucket_key).await?;
+    let objects: Vec<_> = all_objects
+        .into_iter()
+        .filter(|o| o.object_key.starts_with(&prefix))
+        .collect();
+
+    if objects.is_empty() {
+        if output_format.supports_colors() {
+            println!(
+                "{}",
+                format!("No objects found matching prefix '{prefix}'").yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    if output_format.supports_colors() {
+        println!(
+            "{} {} objects to download with concurrency {}",
+            "Found".dimmed(),
+            objects.len().to_string().cyan(),
+            concurrency.to_string().cyan()
+        );
+    }
+
+    // Build per-object destination paths
+    struct DownloadTask {
+        object_key: String,
+        size: u64,
+        dest: PathBuf,
+    }
+
+    let tasks: Vec<DownloadTask> = objects
+        .iter()
+        .map(|obj| {
+            let dest = if flat {
+                // Place all files directly in output_dir, using only the filename portion
+                let filename = Path::new(&obj.object_key)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| obj.object_key.replace('/', "_"));
+                output_dir.join(filename)
+            } else {
+                // Preserve the key structure relative to the prefix
+                let relative = obj
+                    .object_key
+                    .strip_prefix(&prefix)
+                    .unwrap_or(&obj.object_key)
+                    .trim_start_matches('/');
+                output_dir.join(relative)
+            };
+            DownloadTask {
+                object_key: obj.object_key.clone(),
+                size: obj.size,
+                dest,
+            }
+        })
+        .collect();
+
+    // ── multi-progress bars ───────────────────────────────────────────────────
+    let use_progress = !interactive::is_non_interactive();
+    let mp = Arc::new(MultiProgress::new());
+
+    // Overall progress bar: counts completed objects
+    let overall_pb = if use_progress {
+        let pb = mp.add(ProgressBar::new(tasks.len() as u64));
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{spinner:.green} Overall [{bar:40.cyan/blue}] {pos}/{len} ({percent}%) {msg}",
+                )
+                .expect("hardcoded template is valid")
+                .progress_chars("█▓░"),
+        );
+        pb.enable_steady_tick(std::time::Duration::from_millis(100));
+        pb.set_message("downloading…");
+        pb
+    } else {
+        ProgressBar::hidden()
+    };
+
+    // ── spawn parallel tasks ─────────────────────────────────────────────────
+    let semaphore = Arc::new(Semaphore::new(concurrency));
+    let client_arc = Arc::new(client.clone());
+    let bucket_arc = Arc::new(bucket_key.clone());
+    let overall_pb_arc = Arc::new(overall_pb);
+    let mp_arc = mp.clone();
+
+    let start = Instant::now();
+    let mut join_set: JoinSet<BulkDownloadFileResult> = JoinSet::new();
+
+    for task in tasks {
+        let permit = semaphore.clone().acquire_owned().await?;
+        let client = client_arc.clone();
+        let bucket = bucket_arc.clone();
+        let overall_pb = overall_pb_arc.clone();
+        let mp = mp_arc.clone();
+        let use_pb = use_progress;
+
+        join_set.spawn(async move {
+            let object_key = task.object_key.clone();
+            let dest = task.dest.clone();
+            let size = task.size;
+
+            // Skip check: file already present with matching size
+            if skip_existing {
+                if let Ok(meta) = tokio::fs::metadata(&dest).await {
+                    if meta.len() == size {
+                        drop(permit);
+                        overall_pb.inc(1);
+                        return BulkDownloadFileResult {
+                            object_key,
+                            output_path: dest.display().to_string(),
+                            size: Some(size),
+                            skipped: true,
+                            success: true,
+                            error: None,
+                        };
+                    }
+                }
+            }
+
+            // Ensure parent directory exists (for non-flat mode)
+            if let Some(parent) = dest.parent() {
+                if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                    drop(permit);
+                    overall_pb.inc(1);
+                    return BulkDownloadFileResult {
+                        object_key,
+                        output_path: dest.display().to_string(),
+                        size: None,
+                        skipped: false,
+                        success: false,
+                        error: Some(format!("Failed to create directory: {e}")),
+                    };
+                }
+            }
+
+            // Per-file progress bar
+            let file_pb: Option<ProgressBar> = if use_pb {
+                let pb = mp.add(ProgressBar::new(size));
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template(
+                            "  {msg:.cyan} [{bar:35.cyan/blue}] {bytes}/{total_bytes} ({percent}%)",
+                        )
+                        .expect("hardcoded template is valid")
+                        .progress_chars("█▓░"),
+                );
+                let short = if object_key.len() > 30 {
+                    format!("…{}", &object_key[object_key.len() - 29..])
+                } else {
+                    object_key.clone()
+                };
+                pb.set_message(short);
+                Some(pb)
+            } else {
+                None
+            };
+
+            // Perform the download using the OSS client
+            let result = download_with_progress(&client, &bucket, &object_key, &dest, file_pb.as_ref()).await;
+
+            if let Some(pb) = file_pb {
+                pb.finish_and_clear();
+            }
+            drop(permit);
+            overall_pb.inc(1);
+
+            match result {
+                Ok(()) => BulkDownloadFileResult {
+                    object_key,
+                    output_path: dest.display().to_string(),
+                    size: Some(size),
+                    skipped: false,
+                    success: true,
+                    error: None,
+                },
+                Err(e) => BulkDownloadFileResult {
+                    object_key,
+                    output_path: dest.display().to_string(),
+                    size: None,
+                    skipped: false,
+                    success: false,
+                    error: Some(e.to_string()),
+                },
+            }
+        });
+    }
+
+    // Collect results
+    let mut file_results: Vec<BulkDownloadFileResult> = Vec::new();
+    while let Some(res) = join_set.join_next().await {
+        match res {
+            Ok(r) => file_results.push(r),
+            Err(e) => file_results.push(BulkDownloadFileResult {
+                object_key: "unknown".to_string(),
+                output_path: String::new(),
+                size: None,
+                skipped: false,
+                success: false,
+                error: Some(format!("Task panicked: {e}")),
+            }),
+        }
+    }
+
+    // Finish the overall bar
+    overall_pb_arc.finish_with_message("done");
+
+    let elapsed = start.elapsed();
+
+    // Compute summary
+    let downloaded = file_results.iter().filter(|r| r.success && !r.skipped).count();
+    let skipped = file_results.iter().filter(|r| r.skipped).count();
+    let failed = file_results.iter().filter(|r| !r.success).count();
+    let total_bytes: u64 = file_results
+        .iter()
+        .filter(|r| r.success && !r.skipped)
+        .filter_map(|r| r.size)
+        .sum();
+
+    let summary = BulkDownloadSummary {
+        success: failed == 0,
+        downloaded,
+        skipped,
+        failed,
+        total_bytes,
+        total_bytes_human: format_size(total_bytes),
+        elapsed_secs: elapsed.as_secs_f64(),
+        files: file_results,
+    };
+
+    // Output
+    match output_format {
+        OutputFormat::Table => {
+            println!("\n{}", "Bulk Download Summary:".bold());
+            println!("{}", "-".repeat(70));
+
+            for f in &summary.files {
+                if f.skipped {
+                    println!(
+                        "  {} {} {}",
+                        "~".yellow().bold(),
+                        f.object_key.dimmed(),
+                        "(skipped — already exists)".dimmed()
+                    );
+                } else if f.success {
+                    let sz = f.size.map(format_size).unwrap_or_default();
+                    println!(
+                        "  {} {} {}",
+                        "✓".green().bold(),
+                        f.object_key.cyan(),
+                        sz.dimmed()
+                    );
+                } else {
+                    println!(
+                        "  {} {} {}",
+                        "X".red().bold(),
+                        f.object_key,
+                        f.error.as_deref().unwrap_or("unknown error").red()
+                    );
+                }
+            }
+
+            println!("{}", "-".repeat(70));
+            println!(
+                "  {} {} downloaded, {} skipped, {} failed",
+                "Total:".bold(),
+                downloaded.to_string().green(),
+                skipped.to_string().yellow(),
+                failed.to_string().red()
+            );
+            println!(
+                "  {} {} in {:.1}s",
+                "Size:".bold(),
+                summary.total_bytes_human,
+                elapsed.as_secs_f64()
+            );
+
+            if failed > 0 {
+                println!(
+                    "\n  {} {} file(s) failed. Re-run with {} to skip already-downloaded files.",
+                    "Hint:".yellow().bold(),
+                    failed,
+                    "--skip-existing".cyan()
+                );
+            }
+        }
+        _ => {
+            output_format.write(&summary)?;
+        }
+    }
+
+    if summary.failed > 0 {
+        anyhow::bail!("{} file(s) failed to download", summary.failed);
+    }
+
+    Ok(())
+}
+
+// ──────────────────────────── helpers ────────────────────────────────────────
+
+/// Download a single object, updating an optional per-file progress bar.
+///
+/// We use the public `download_object` API which handles all the retry/redirect
+/// logic internally. The per-file progress bar is updated by wrapping the dest
+/// path in a temporary file and tracking bytes written.
+async fn download_with_progress(
+    client: &OssClient,
+    bucket_key: &str,
+    object_key: &str,
+    dest: &Path,
+    file_pb: Option<&ProgressBar>,
+) -> Result<()> {
+    // When we have a progress bar we do the streaming manually so we can
+    // call set_position. When no progress bar is needed (non-interactive)
+    // we delegate to the existing client method which handles retries etc.
+    if let Some(pb) = file_pb {
+        download_streaming(client, bucket_key, object_key, dest, pb).await
+    } else {
+        client.download_object(bucket_key, object_key, dest).await
+    }
+}
+
+/// Stream-download with manual progress reporting.
+async fn download_streaming(
+    client: &OssClient,
+    bucket_key: &str,
+    object_key: &str,
+    dest: &Path,
+    pb: &ProgressBar,
+) -> Result<()> {
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let signed = client
+        .get_signed_download_url(bucket_key, object_key, None)
+        .await?;
+
+    let download_url = signed
+        .url
+        .ok_or_else(|| anyhow::anyhow!("No download URL returned for '{object_key}'"))?;
+
+    // Build a plain reqwest client for the S3 direct download (no auth needed)
+    let response = reqwest::Client::new()
+        .get(&download_url)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to start download for '{object_key}': {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!(
+            "Download failed for '{object_key}': HTTP {status} — {body}"
+        ));
+    }
+
+    if let Some(len) = response.content_length() {
+        pb.set_length(len);
+    }
+
+    let mut file = tokio::fs::File::create(dest).await.map_err(|e| {
+        anyhow::anyhow!("Failed to create '{}': {}", dest.display(), e)
+    })?;
+
+    let mut stream = response.bytes_stream();
+    let mut written: u64 = 0;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|e| anyhow::anyhow!("Download error for '{object_key}': {e}"))?;
+        file.write_all(&chunk).await.map_err(|e| {
+            anyhow::anyhow!("Write error for '{}': {}", dest.display(), e)
+        })?;
+        written += chunk.len() as u64;
+        pb.set_position(written);
+    }
+
+    file.flush().await?;
+    Ok(())
+}

--- a/raps-cli/src/commands/object/mod.rs
+++ b/raps-cli/src/commands/object/mod.rs
@@ -7,6 +7,7 @@
 
 mod copy;
 pub(crate) mod download;
+mod download_bulk;
 pub(crate) mod secret_scan;
 pub(crate) mod upload;
 
@@ -20,6 +21,7 @@ use raps_oss::OssClient;
 
 use copy::{batch_copy_objects, batch_rename_objects, copy_object, rename_object};
 use download::{delete_object, download_object, get_signed_url, list_objects, object_info};
+use download_bulk::download_bulk;
 use upload::{upload_batch, upload_object};
 
 #[derive(Debug, Subcommand)]
@@ -90,6 +92,32 @@ pub enum ObjectCommands {
         /// Output file path (defaults to object key; use `-` for stdout)
         #[arg(long = "out-file")]
         out_file: Option<PathBuf>,
+    },
+
+    /// Download multiple objects in parallel matching a prefix
+    #[command(name = "download-bulk")]
+    DownloadBulk {
+        /// Bucket key
+        bucket: Option<String>,
+
+        /// Object key prefix to match (e.g. `models/` to download all objects under that path)
+        prefix: String,
+
+        /// Directory to write downloaded files into
+        #[arg(long, default_value = ".")]
+        output_dir: PathBuf,
+
+        /// Maximum number of parallel downloads
+        #[arg(long, default_value = "4")]
+        concurrency: usize,
+
+        /// Skip files that already exist locally with a matching size (on by default)
+        #[arg(long, default_value = "true")]
+        skip_existing: bool,
+
+        /// Download all files directly into --output-dir without preserving the key prefix structure
+        #[arg(long)]
+        flat: bool,
     },
 
     /// List objects in a bucket
@@ -254,6 +282,26 @@ impl ObjectCommands {
                 object,
                 out_file,
             } => download_object(client, bucket, object, out_file, output_format).await,
+            ObjectCommands::DownloadBulk {
+                bucket,
+                prefix,
+                output_dir,
+                concurrency: cmd_concurrency,
+                skip_existing,
+                flat,
+            } => {
+                download_bulk(
+                    client,
+                    bucket,
+                    prefix,
+                    output_dir,
+                    cmd_concurrency,
+                    skip_existing,
+                    flat,
+                    output_format,
+                )
+                .await
+            }
             ObjectCommands::List { bucket, limit } => {
                 list_objects(client, bucket, limit, output_format).await
             }

--- a/raps-cli/src/commands/pipeline.rs
+++ b/raps-cli/src/commands/pipeline.rs
@@ -301,7 +301,6 @@ impl PipelineCommands {
                 dry_run,
                 var,
                 max_parallel,
-            } => run_pipeline(&file, ignore_failure, dry_run, var, max_parallel, output_format).await,
                 resume,
                 reset,
                 reset_from,
@@ -311,6 +310,7 @@ impl PipelineCommands {
                     ignore_failure,
                     dry_run,
                     var,
+                    max_parallel,
                     output_format,
                     resume,
                     reset,
@@ -917,52 +917,20 @@ async fn run_pipeline(
                     println!("  {} parallel steps", "⫸".dimmed());
                 } else if step.for_each.is_some() {
                     println!("  {} for-each loop", "⟳".dimmed());
-        // Skip already-completed steps when resuming
-        if state.is_completed(&step.name) {
-            if output_format.supports_colors() {
-                println!(
-                    "  {} {} (skipped — already completed)",
-                    "✓".green().dimmed(),
-                    step.name.dimmed()
-                );
-            }
-            skipped += 1;
-            continue;
-        }
-
-        let outcome = execute_step(
-            step.clone(),
-            pipeline.variables.clone(),
-            context.clone(),
-            pipeline.defaults.clone(),
-            output_format,
-            dry_run,
-        )
-        .await?;
-
-        match outcome {
-            StepOutcome::Success(code) => {
-                if output_format.supports_colors() {
-                    println!("  {} Success", "✓".green().bold());
                 }
-                state.mark(&step.name, StepRunStatus::Completed, Some(code));
-                state.save(&canonical_file);
-                passed += 1;
             }
-            StepOutcome::Failed(code) => {
+
+            // Skip already-completed steps when resuming
+            if state.is_completed(&step.name) {
                 if output_format.supports_colors() {
-                    println!("  {} Failed (exit code: {})", "✗".red().bold(), code);
-                }
-                state.mark(&step.name, StepRunStatus::Failed, Some(code));
-                state.save(&canonical_file);
-                failed += 1;
-                if !step.ignore_failure && !global_ignore_failure {
-                    anyhow::bail!(
-                        "Pipeline aborted at step '{}' (exit code: {})",
-                        step.name,
-                        code
+                    println!(
+                        "  {} {} (skipped — already completed)",
+                        "✓".green().dimmed(),
+                        step.name.dimmed()
                     );
                 }
+                skipped += 1;
+                continue;
             }
 
             let outcome = execute_step(
@@ -976,16 +944,20 @@ async fn run_pipeline(
             .await?;
 
             match outcome {
-                StepOutcome::Success(_) => {
+                StepOutcome::Success(code) => {
                     if output_format.supports_colors() {
                         println!("  {} Success", "✓".green().bold());
                     }
+                    state.mark(&step.name, StepRunStatus::Completed, Some(code));
+                    state.save(&canonical_file);
                     passed += 1;
                 }
                 StepOutcome::Failed(code) => {
                     if output_format.supports_colors() {
                         println!("  {} Failed (exit code: {})", "✗".red().bold(), code);
                     }
+                    state.mark(&step.name, StepRunStatus::Failed, Some(code));
+                    state.save(&canonical_file);
                     failed += 1;
                     if !step.ignore_failure && !global_ignore_failure {
                         anyhow::bail!(
@@ -999,6 +971,8 @@ async fn run_pipeline(
                     if output_format.supports_colors() {
                         println!("  {} Skipped (condition not met)", "○".dimmed());
                     }
+                    state.mark(&step.name, StepRunStatus::Skipped, None);
+                    state.save(&canonical_file);
                     skipped += 1;
                 }
             }
@@ -1087,9 +1061,6 @@ async fn run_pipeline(
                     Ok(Err(e)) => return Err(e),
                     Err(e) => anyhow::bail!("Parallel step task panicked: {}", e),
                 }
-                state.mark(&step.name, StepRunStatus::Skipped, None);
-                state.save(&canonical_file);
-                skipped += 1;
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `raps object download-bulk <prefix>` subcommand that downloads all OSS objects matching a key prefix in parallel
- Uses `tokio::task::JoinSet` with a `tokio::sync::Semaphore` to cap concurrent downloads (default 4, configurable via `--concurrency N`)
- Renders a `indicatif::MultiProgress` display: one per-file progress bar plus an overall completion bar
- `--flat` flag downloads all files directly into `--output-dir` without preserving the key prefix hierarchy
- `--skip-existing` (on by default) skips files whose local size already matches the remote size
- Prints a final summary: N downloaded, M skipped, K failed, total MB transferred, elapsed seconds
- Also fixes two pre-existing merge-conflict residues in `pipeline.rs` that prevented compilation, and removes a duplicate `glob` entry in `raps-cli/Cargo.toml`

## Usage

```
# Download everything under "models/" into ./downloads/, 8 parallel streams
raps object download-bulk --bucket my-bucket models/ --output-dir ./downloads --concurrency 8

# Flatten all files into a single directory
raps object download-bulk --bucket my-bucket assets/ --output-dir ./flat --flat

# Re-run safely — already-downloaded files are skipped
raps object download-bulk --bucket my-bucket models/ --output-dir ./downloads
```

## Test plan

- [ ] `cargo build -p raps-cli` passes with no errors
- [ ] `cargo clippy -p raps-cli` produces no new warnings
- [ ] `raps object download-bulk --help` shows the new subcommand and all flags
- [ ] Running against a real bucket downloads all matching objects in parallel
- [ ] Re-running with `--skip-existing` skips already-downloaded files with matching size
- [ ] `--flat` places all files in the top-level output directory
- [ ] `--concurrency 1` produces single-threaded sequential downloads

Closes #163

---
Generated with [Claude Code](https://claude.com/claude-code)