### PR TITLE
refactor(cli): extract duplicated progress bar setup into shared helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -594,9 +600,9 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -610,11 +616,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "rustix 1.1.4",
  "serde",
@@ -982,6 +988,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1042,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1568,6 +1594,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1726,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,7 +1769,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1723,7 +1792,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -1845,6 +1914,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1866,6 +1947,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1965,7 +2065,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2058,6 +2158,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2355,12 +2461,14 @@ dependencies = [
  "ed25519-dalek",
  "fs2",
  "futures-util",
+ "glob",
  "hex",
  "hmac",
  "hostname",
  "indicatif",
  "insta",
  "keyring",
+ "notify",
  "nu-ansi-term",
  "predicates",
  "rand 0.8.5",
@@ -2385,6 +2493,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2",
  "shlex",
  "tempfile",
@@ -2424,6 +2533,8 @@ version = "5.3.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
+ "directories",
  "futures-util",
  "indicatif",
  "insta",
@@ -2605,7 +2716,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2656,7 +2767,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2880,7 +3000,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2909,7 +3029,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2922,7 +3042,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3023,7 +3143,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3036,7 +3156,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3228,7 +3348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.1.1",
  "signal-hook",
 ]
 
@@ -3529,7 +3649,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3687,7 +3807,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4103,7 +4223,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4609,7 +4729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/raps-cli/Cargo.toml
+++ b/raps-cli/Cargo.toml
@@ -130,9 +130,6 @@ hex.workspace = true
 # SHA-1 for sync checksum comparison
 sha1.workspace = true
 
-# Glob patterns for sync --exclude
-glob.workspace = true
-
 # Worker hostname identification
 hostname = { workspace = true, optional = true }
 

--- a/raps-cli/src/commands/admin/csv_ops.rs
+++ b/raps-cli/src/commands/admin/csv_ops.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use colored::Colorize;
-use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 
 use raps_acc::admin::AccountAdminClient;
@@ -473,18 +472,10 @@ pub(crate) async fn execute_csv_import(
 
     // Show spinner during concurrent import (up to 10 parallel requests)
     let spinner = if output_format.supports_colors() {
-        let sp = ProgressBar::new_spinner();
-        sp.set_style(
-            ProgressStyle::with_template("{spinner:.cyan} {msg}")
-                .expect("hardcoded progress template is valid")
-                .tick_strings(&[
-                    "\u{280B}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283C}", "\u{2834}",
-                    "\u{2826}", "\u{2827}", "\u{2807}", "\u{280F}",
-                ]),
-        );
-        sp.set_message(format!("Importing {} users concurrently...", total));
-        sp.enable_steady_tick(std::time::Duration::from_millis(100));
-        Some(sp)
+        Some(raps_kernel::progress::spinner(&format!(
+            "Importing {} users concurrently...",
+            total
+        )))
     } else {
         None
     };

--- a/raps-cli/src/commands/pipeline.rs
+++ b/raps-cli/src/commands/pipeline.rs
@@ -301,7 +301,6 @@ impl PipelineCommands {
                 dry_run,
                 var,
                 max_parallel,
-            } => run_pipeline(&file, ignore_failure, dry_run, var, max_parallel, output_format).await,
                 resume,
                 reset,
                 reset_from,
@@ -311,6 +310,7 @@ impl PipelineCommands {
                     ignore_failure,
                     dry_run,
                     var,
+                    max_parallel,
                     output_format,
                     resume,
                     reset,
@@ -917,52 +917,20 @@ async fn run_pipeline(
                     println!("  {} parallel steps", "⫸".dimmed());
                 } else if step.for_each.is_some() {
                     println!("  {} for-each loop", "⟳".dimmed());
-        // Skip already-completed steps when resuming
-        if state.is_completed(&step.name) {
-            if output_format.supports_colors() {
-                println!(
-                    "  {} {} (skipped — already completed)",
-                    "✓".green().dimmed(),
-                    step.name.dimmed()
-                );
-            }
-            skipped += 1;
-            continue;
-        }
-
-        let outcome = execute_step(
-            step.clone(),
-            pipeline.variables.clone(),
-            context.clone(),
-            pipeline.defaults.clone(),
-            output_format,
-            dry_run,
-        )
-        .await?;
-
-        match outcome {
-            StepOutcome::Success(code) => {
-                if output_format.supports_colors() {
-                    println!("  {} Success", "✓".green().bold());
                 }
-                state.mark(&step.name, StepRunStatus::Completed, Some(code));
-                state.save(&canonical_file);
-                passed += 1;
             }
-            StepOutcome::Failed(code) => {
+
+            // Skip already-completed steps when resuming
+            if state.is_completed(&step.name) {
                 if output_format.supports_colors() {
-                    println!("  {} Failed (exit code: {})", "✗".red().bold(), code);
-                }
-                state.mark(&step.name, StepRunStatus::Failed, Some(code));
-                state.save(&canonical_file);
-                failed += 1;
-                if !step.ignore_failure && !global_ignore_failure {
-                    anyhow::bail!(
-                        "Pipeline aborted at step '{}' (exit code: {})",
-                        step.name,
-                        code
+                    println!(
+                        "  {} {} (skipped — already completed)",
+                        "✓".green().dimmed(),
+                        step.name.dimmed()
                     );
                 }
+                skipped += 1;
+                continue;
             }
 
             let outcome = execute_step(
@@ -976,16 +944,20 @@ async fn run_pipeline(
             .await?;
 
             match outcome {
-                StepOutcome::Success(_) => {
+                StepOutcome::Success(code) => {
                     if output_format.supports_colors() {
                         println!("  {} Success", "✓".green().bold());
                     }
+                    state.mark(&step.name, StepRunStatus::Completed, Some(code));
+                    state.save(&canonical_file);
                     passed += 1;
                 }
                 StepOutcome::Failed(code) => {
                     if output_format.supports_colors() {
                         println!("  {} Failed (exit code: {})", "✗".red().bold(), code);
                     }
+                    state.mark(&step.name, StepRunStatus::Failed, Some(code));
+                    state.save(&canonical_file);
                     failed += 1;
                     if !step.ignore_failure && !global_ignore_failure {
                         anyhow::bail!(
@@ -999,6 +971,8 @@ async fn run_pipeline(
                     if output_format.supports_colors() {
                         println!("  {} Skipped (condition not met)", "○".dimmed());
                     }
+                    state.mark(&step.name, StepRunStatus::Skipped, None);
+                    state.save(&canonical_file);
                     skipped += 1;
                 }
             }
@@ -1087,9 +1061,6 @@ async fn run_pipeline(
                     Ok(Err(e)) => return Err(e),
                     Err(e) => anyhow::bail!("Parallel step task panicked: {}", e),
                 }
-                state.mark(&step.name, StepRunStatus::Skipped, None);
-                state.save(&canonical_file);
-                skipped += 1;
             }
         }
     }

--- a/raps-cli/src/commands/reality.rs
+++ b/raps-cli/src/commands/reality.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 use clap::Subcommand;
 use colored::Colorize;
 use dialoguer::{Input, Select};
-use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -381,13 +380,7 @@ async fn check_status(
     _output_format: OutputFormat,
 ) -> Result<()> {
     if wait {
-        let spinner = ProgressBar::new_spinner();
-        spinner.set_style(
-            ProgressStyle::default_spinner()
-                .template("{spinner:.cyan} {msg}")
-                .expect("valid progress template"),
-        );
-        spinner.enable_steady_tick(Duration::from_millis(100));
+        let spinner = raps_kernel::progress::spinner("");
 
         // 4-hour timeout — photogrammetry processing can legitimately take hours
         let timeout = Duration::from_secs(4 * 60 * 60);

--- a/raps-cli/src/commands/report/mod.rs
+++ b/raps-cli/src/commands/report/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 use anyhow::Result;
 use clap::Subcommand;
 use colored::Colorize;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::ProgressBar;
 use serde::Serialize;
 
 use raps_acc::admin::AccountAdminClient;
@@ -233,18 +233,7 @@ pub(super) fn create_progress_bar(
     if !output_format.supports_colors() {
         return None;
     }
-    let template = format!(
-        "{{spinner:.green}} [{{bar:40.cyan/blue}}] {{pos}}/{{len}} {}",
-        message
-    );
-    let pb = ProgressBar::new(count);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template(&template)
-            .expect("valid progress template")
-            .progress_chars("=>-"),
-    );
-    Some(pb)
+    Some(raps_kernel::progress::bulk_progress(count, message))
 }
 
 pub(super) fn print_report_header(


### PR DESCRIPTION
## Summary

- **`commands/reality.rs`**: Replace 7-line inline `ProgressBar::new_spinner()` + `ProgressStyle::default_spinner()` setup in `check_status()` with `raps_kernel::progress::spinner()`
- **`commands/admin/csv_ops.rs`**: Replace 11-line inline spinner setup (including custom `tick_strings`) in `execute_csv_import()` with `raps_kernel::progress::spinner()`
- **`commands/report/mod.rs`**: Replace the inline body of `create_progress_bar()` (manual `ProgressStyle::default_bar` + dynamic template string + `progress_chars`) with a single delegate call to `raps_kernel::progress::bulk_progress()`

The `raps_kernel::progress` module already provides `spinner()`, `file_progress()`, `item_progress()`, and `bulk_progress()` helpers that handle non-interactive mode, steady-tick setup, and consistent styling. This PR eliminates the remaining modules that bypassed those helpers and constructed `indicatif` types directly.

Also fixes two pre-existing worktree issues unrelated to the refactor:
- Remove duplicate `glob.workspace = true` entry in `raps-cli/Cargo.toml`
- Restore `raps-cli/src/commands/pipeline.rs` from main (worktree had a corrupted match arm and interleaved code from an incomplete `--resume/--reset/--reset-from` feature merge)

## Test plan

- [x] `cargo build -p raps-cli` compiles cleanly
- [x] `cargo clippy -p raps-cli` shows no new warnings
- [ ] Manual smoke test: `raps reality status <id> --wait` shows spinner
- [ ] Manual smoke test: `raps admin user import --from-csv file.csv --project <id>` shows spinner
- [ ] Manual smoke test: `raps report rfi-summary` shows progress bar

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)