### PR TITLE
fix(cli): complete or remove plugin system dead code

### DIFF
--- a/raps-cli/Cargo.toml
+++ b/raps-cli/Cargo.toml
@@ -130,9 +130,6 @@ hex.workspace = true
 # SHA-1 for sync checksum comparison
 sha1.workspace = true
 
-# Glob patterns for sync --exclude
-glob.workspace = true
-
 # Worker hostname identification
 hostname = { workspace = true, optional = true }
 

--- a/raps-cli/src/commands/pipeline.rs
+++ b/raps-cli/src/commands/pipeline.rs
@@ -301,7 +301,6 @@ impl PipelineCommands {
                 dry_run,
                 var,
                 max_parallel,
-            } => run_pipeline(&file, ignore_failure, dry_run, var, max_parallel, output_format).await,
                 resume,
                 reset,
                 reset_from,
@@ -311,6 +310,7 @@ impl PipelineCommands {
                     ignore_failure,
                     dry_run,
                     var,
+                    max_parallel,
                     output_format,
                     resume,
                     reset,
@@ -917,52 +917,20 @@ async fn run_pipeline(
                     println!("  {} parallel steps", "⫸".dimmed());
                 } else if step.for_each.is_some() {
                     println!("  {} for-each loop", "⟳".dimmed());
-        // Skip already-completed steps when resuming
-        if state.is_completed(&step.name) {
-            if output_format.supports_colors() {
-                println!(
-                    "  {} {} (skipped — already completed)",
-                    "✓".green().dimmed(),
-                    step.name.dimmed()
-                );
-            }
-            skipped += 1;
-            continue;
-        }
-
-        let outcome = execute_step(
-            step.clone(),
-            pipeline.variables.clone(),
-            context.clone(),
-            pipeline.defaults.clone(),
-            output_format,
-            dry_run,
-        )
-        .await?;
-
-        match outcome {
-            StepOutcome::Success(code) => {
-                if output_format.supports_colors() {
-                    println!("  {} Success", "✓".green().bold());
                 }
-                state.mark(&step.name, StepRunStatus::Completed, Some(code));
-                state.save(&canonical_file);
-                passed += 1;
             }
-            StepOutcome::Failed(code) => {
+
+            // Skip already-completed steps when resuming
+            if state.is_completed(&step.name) {
                 if output_format.supports_colors() {
-                    println!("  {} Failed (exit code: {})", "✗".red().bold(), code);
-                }
-                state.mark(&step.name, StepRunStatus::Failed, Some(code));
-                state.save(&canonical_file);
-                failed += 1;
-                if !step.ignore_failure && !global_ignore_failure {
-                    anyhow::bail!(
-                        "Pipeline aborted at step '{}' (exit code: {})",
-                        step.name,
-                        code
+                    println!(
+                        "  {} {} (skipped — already completed)",
+                        "✓".green().dimmed(),
+                        step.name.dimmed()
                     );
                 }
+                skipped += 1;
+                continue;
             }
 
             let outcome = execute_step(
@@ -976,16 +944,20 @@ async fn run_pipeline(
             .await?;
 
             match outcome {
-                StepOutcome::Success(_) => {
+                StepOutcome::Success(code) => {
                     if output_format.supports_colors() {
                         println!("  {} Success", "✓".green().bold());
                     }
+                    state.mark(&step.name, StepRunStatus::Completed, Some(code));
+                    state.save(&canonical_file);
                     passed += 1;
                 }
                 StepOutcome::Failed(code) => {
                     if output_format.supports_colors() {
                         println!("  {} Failed (exit code: {})", "✗".red().bold(), code);
                     }
+                    state.mark(&step.name, StepRunStatus::Failed, Some(code));
+                    state.save(&canonical_file);
                     failed += 1;
                     if !step.ignore_failure && !global_ignore_failure {
                         anyhow::bail!(
@@ -999,6 +971,8 @@ async fn run_pipeline(
                     if output_format.supports_colors() {
                         println!("  {} Skipped (condition not met)", "○".dimmed());
                     }
+                    state.mark(&step.name, StepRunStatus::Skipped, None);
+                    state.save(&canonical_file);
                     skipped += 1;
                 }
             }
@@ -1087,9 +1061,6 @@ async fn run_pipeline(
                     Ok(Err(e)) => return Err(e),
                     Err(e) => anyhow::bail!("Parallel step task panicked: {}", e),
                 }
-                state.mark(&step.name, StepRunStatus::Skipped, None);
-                state.save(&canonical_file);
-                skipped += 1;
             }
         }
     }

--- a/raps-cli/src/main.rs
+++ b/raps-cli/src/main.rs
@@ -916,6 +916,25 @@ async fn run(cli: Cli) -> Result<()> {
                         continue;
                     }
 
+                    // Expand aliases: if the first word matches a configured alias,
+                    // replace the line with the aliased command before parsing.
+                    let line = {
+                        let plugin_cfg = crate::plugins::PluginConfig::load()
+                            .unwrap_or_default();
+                        let first_word = line.split_whitespace().next().unwrap_or("");
+                        if let Some(alias_cmd) = plugin_cfg.get_alias(first_word) {
+                            let rest = line[first_word.len()..].trim_start();
+                            if rest.is_empty() {
+                                alias_cmd.to_string()
+                            } else {
+                                format!("{} {}", alias_cmd, rest)
+                            }
+                        } else {
+                            line.to_string()
+                        }
+                    };
+                    let line = line.as_str();
+
                     let mut args = match shlex::split(line) {
                         Some(args) => args,
                         None => {
@@ -1296,6 +1315,12 @@ async fn execute_command(
     let cmd_name = command_name(&command);
     tracing::info!(command = cmd_name, "Executing command");
 
+    // Run pre-command hooks (ignore errors — hooks should not block the command)
+    let plugin_manager = crate::plugins::PluginManager::default();
+    if let Err(e) = plugin_manager.run_pre_hooks(cmd_name) {
+        tracing::warn!(command = cmd_name, error = %e, "Pre-command hook failed");
+    }
+
     // Helper closure to create clients on demand
     let get_auth_client =
         || -> AuthClient { AuthClient::new_with_http_config(config.clone(), http_config.clone()) };
@@ -1564,6 +1589,11 @@ async fn execute_command(
                 anyhow::bail!("Plugin '{}' exited with code {}", plugin_name, code);
             }
         }
+    }
+
+    // Run post-command hooks (ignore errors — hooks should not mask the command result)
+    if let Err(e) = plugin_manager.run_post_hooks(cmd_name) {
+        tracing::warn!(command = cmd_name, error = %e, "Post-command hook failed");
     }
 
     Ok(())

--- a/raps-cli/src/mcp/auth_guidance.rs
+++ b/raps-cli/src/mcp/auth_guidance.rs
@@ -8,11 +8,7 @@
 //!
 //! Items in this module are pre-built for integration into the MCP auth flow.
 
-use raps_kernel::auth::AuthClient;
-use raps_kernel::config::Config;
-
 /// Authentication requirement for MCP tools
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthRequirement {
     /// Requires 2-legged OAuth (client credentials)
@@ -24,78 +20,17 @@ pub enum AuthRequirement {
 }
 
 /// Current authentication state
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AuthState {
-    /// Whether APS_CLIENT_ID is configured
-    pub has_client_id: bool,
-    /// Whether APS_CLIENT_SECRET is configured
-    pub has_client_secret: bool,
     /// Whether 2-legged auth succeeds
     pub two_legged_valid: bool,
     /// Whether 3-legged token exists and is valid
     pub three_legged_valid: bool,
-    /// Whether 3-legged token exists but is expired
-    pub three_legged_expired: bool,
-}
-
-#[allow(dead_code)]
-impl AuthState {
-    /// Check if any credentials are configured
-    pub fn has_any_credentials(&self) -> bool {
-        self.has_client_id || self.has_client_secret
-    }
-
-    /// Check if 2-legged credentials are complete
-    pub fn has_complete_2leg_credentials(&self) -> bool {
-        self.has_client_id && self.has_client_secret
-    }
 }
 
 // ============================================================================
 // Instruction Constants
 // ============================================================================
-
-/// Full onboarding guide for first-time users
-#[allow(dead_code)]
-pub const SETUP_INSTRUCTIONS: &str = r#"
-To set up authentication for RAPS MCP Server:
-
-1. Go to https://aps.autodesk.com/ (Autodesk Platform Services)
-2. Sign in or create an Autodesk account
-3. Create a new application or select an existing one
-4. Copy your Client ID and Client Secret
-5. Set environment variables before starting the MCP server:
-
-   For Unix/macOS:
-     export APS_CLIENT_ID="your_client_id"
-     export APS_CLIENT_SECRET="your_client_secret"
-
-   For Windows (PowerShell):
-     $env:APS_CLIENT_ID="your_client_id"
-     $env:APS_CLIENT_SECRET="your_client_secret"
-
-   Or add to your MCP server configuration (claude_desktop_config.json):
-     {
-       "mcpServers": {
-         "raps": {
-           "command": "raps",
-           "args": ["serve"],
-           "env": {
-             "APS_CLIENT_ID": "your_client_id",
-             "APS_CLIENT_SECRET": "your_client_secret"
-           }
-         }
-       }
-     }
-
-For 3-legged auth in MCP/headless environments, use the device code flow:
-  raps auth login --device
-This will give you a short code to enter at https://rapscli.xyz/device — no
-browser on the same machine required.
-
-For more information: https://rapscli.xyz/docs/auth
-"#;
 
 /// Missing client ID guidance
 pub const MISSING_CLIENT_ID: &str = r#"
@@ -121,21 +56,6 @@ The Client Secret is required for authentication. To get your Client Secret:
 Note: Keep your Client Secret secure and never share it publicly.
 "#;
 
-/// Prompt to perform 3-legged authentication
-#[allow(dead_code)]
-pub const THREE_LEGGED_PROMPT: &str = r#"
-To access BIM 360/ACC data (hubs, projects, folders, files, issues, RFIs), you need to log in with your Autodesk account.
-
-Use the `auth_login` tool to start the authentication process, or run:
-  raps auth login
-
-This will open a browser window for you to sign in with your Autodesk credentials.
-
-In headless or MCP environments (no browser available), use the device code flow:
-  raps auth login --device
-You'll receive a short code to enter at https://rapscli.xyz/device from any device.
-"#;
-
 /// Tool availability summary header
 pub const TOOL_AVAILABILITY_HEADER: &str = "\nTool Availability:\n";
 
@@ -144,7 +64,6 @@ pub const TOOL_AVAILABILITY_HEADER: &str = "\nTool Availability:\n";
 // ============================================================================
 
 /// Get the authentication requirement for a tool
-#[allow(dead_code)]
 pub fn get_tool_auth_requirement(tool_name: &str) -> AuthRequirement {
     match tool_name {
         // Auth tools - work with either
@@ -219,45 +138,6 @@ pub fn get_tool_auth_requirement(tool_name: &str) -> AuthRequirement {
 
         // Default to 2-legged for unknown tools
         _ => AuthRequirement::TwoLegged,
-    }
-}
-
-// ============================================================================
-// Auth State Helper
-// ============================================================================
-
-/// Compute current authentication state from config and auth client
-#[allow(dead_code)]
-pub async fn get_auth_state(config: &Config, auth_client: &AuthClient) -> AuthState {
-    let has_client_id = !config.client_id.is_empty();
-    let has_client_secret = !config.client_secret.is_empty();
-
-    // Check 2-legged validity
-    let two_legged_valid = if has_client_id && has_client_secret {
-        auth_client.get_token().await.is_ok()
-    } else {
-        false
-    };
-
-    // Check 3-legged validity
-    let (three_legged_valid, three_legged_expired) = match auth_client.get_3leg_token().await {
-        Ok(_) => (true, false),
-        Err(e) => {
-            let err_msg = e.to_string().to_lowercase();
-            if err_msg.contains("expired") || err_msg.contains("refresh") {
-                (false, true)
-            } else {
-                (false, false)
-            }
-        }
-    };
-
-    AuthState {
-        has_client_id,
-        has_client_secret,
-        two_legged_valid,
-        three_legged_valid,
-        three_legged_expired,
     }
 }
 
@@ -398,54 +278,11 @@ pub fn get_tool_availability_summary(state: &AuthState) -> String {
 mod tests {
     use super::*;
 
-    fn make_auth_state(
-        has_client_id: bool,
-        has_client_secret: bool,
-        two_legged_valid: bool,
-        three_legged_valid: bool,
-        three_legged_expired: bool,
-    ) -> AuthState {
+    fn make_auth_state(two_legged_valid: bool, three_legged_valid: bool) -> AuthState {
         AuthState {
-            has_client_id,
-            has_client_secret,
             two_legged_valid,
             three_legged_valid,
-            three_legged_expired,
         }
-    }
-
-    // --- has_any_credentials ---
-
-    #[test]
-    fn test_has_any_credentials_both() {
-        let state = make_auth_state(true, true, false, false, false);
-        assert!(state.has_any_credentials());
-    }
-
-    #[test]
-    fn test_has_any_credentials_one() {
-        let state = make_auth_state(true, false, false, false, false);
-        assert!(state.has_any_credentials());
-    }
-
-    #[test]
-    fn test_has_any_credentials_none() {
-        let state = make_auth_state(false, false, false, false, false);
-        assert!(!state.has_any_credentials());
-    }
-
-    // --- has_complete_2leg_credentials ---
-
-    #[test]
-    fn test_has_complete_2leg_both() {
-        let state = make_auth_state(true, true, false, false, false);
-        assert!(state.has_complete_2leg_credentials());
-    }
-
-    #[test]
-    fn test_has_complete_2leg_partial() {
-        let state = make_auth_state(true, false, false, false, false);
-        assert!(!state.has_complete_2leg_credentials());
     }
 
     // --- get_tool_auth_requirement ---
@@ -519,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_availability_summary_all_valid() {
-        let state = make_auth_state(true, true, true, true, false);
+        let state = make_auth_state(true, true);
         let summary = get_tool_availability_summary(&state);
         assert!(!summary.contains("✗"));
         assert!(summary.contains("✓"));
@@ -527,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_availability_summary_no_auth() {
-        let state = make_auth_state(false, false, false, false, false);
+        let state = make_auth_state(false, false);
         let summary = get_tool_availability_summary(&state);
         assert!(!summary.contains("✓"));
         assert!(summary.contains("✗"));

--- a/raps-cli/src/mcp/tools_oss.rs
+++ b/raps-cli/src/mcp/tools_oss.rs
@@ -21,7 +21,6 @@ impl RapsServer {
 
     pub(crate) async fn auth_status(&self) -> String {
         let auth = self.get_auth_client().await;
-        let config = self.config();
         let mut status = String::new();
 
         // Check 2-legged
@@ -37,29 +36,22 @@ impl RapsServer {
         };
 
         // Check 3-legged
-        let (three_legged_valid, three_legged_expired) = match auth.get_3leg_token().await {
+        let three_legged_valid = match auth.get_3leg_token().await {
             Ok(_) => {
                 status.push_str("3-legged OAuth: Valid (user logged in)\n");
-                (true, false)
+                true
             }
-            Err(e) => {
+            Err(_) => {
                 status
                     .push_str("3-legged OAuth: Not logged in (run 'raps auth login' to log in)\n");
-                let err_msg = e.to_string().to_lowercase();
-                (
-                    false,
-                    err_msg.contains("expired") || err_msg.contains("refresh"),
-                )
+                false
             }
         };
 
         // Append tool availability summary
         let auth_state = super::auth_guidance::AuthState {
-            has_client_id: !config.client_id.is_empty(),
-            has_client_secret: !config.client_secret.is_empty(),
             two_legged_valid,
             three_legged_valid,
-            three_legged_expired,
         };
         status.push_str(&super::auth_guidance::get_tool_availability_summary(
             &auth_state,

--- a/raps-cli/src/plugins.rs
+++ b/raps-cli/src/plugins.rs
@@ -127,8 +127,9 @@ impl PluginConfig {
         Ok(proj_dirs.config_dir().join("plugins.json"))
     }
 
-    /// Get an alias command if defined
-    #[allow(dead_code)]
+    /// Get an alias command if defined.
+    ///
+    /// Used by alias expansion in the interactive shell.
     pub fn get_alias(&self, name: &str) -> Option<&str> {
         self.aliases.get(name).map(|s| s.as_str())
     }
@@ -461,14 +462,12 @@ impl PluginManager {
     }
 
     /// Run pre-command hooks
-    #[allow(dead_code)]
     pub fn run_pre_hooks(&self, command: &str) -> Result<()> {
         let hook_key = format!("pre_{}", command);
         self.run_hooks(&hook_key)
     }
 
     /// Run post-command hooks
-    #[allow(dead_code)]
     pub fn run_post_hooks(&self, command: &str) -> Result<()> {
         let hook_key = format!("post_{}", command);
         self.run_hooks(&hook_key)


### PR DESCRIPTION
## Summary

- **Fixed pipeline syntax corruption** in `pipeline.rs`: The `PipelineCommands::Run` match arm had two overlapping destructuring patterns from an incomplete merge of the idempotent-pipeline feature (#221). Fixed by combining into a single correct arm binding all fields. Also fixed the sequential-step loop body where an unclosed `if` block caused duplicate `execute_step` calls and a stray `state.mark` call in the parallel branch.

- **Completed the plugin hook system** (`plugins.rs`, `main.rs`): `run_pre_hooks` and `run_post_hooks` were fully implemented but never called (suppressed with `#[allow(dead_code)]`). Now wired into `execute_command()` to run configured hooks around every command dispatch.

- **Completed alias expansion** (`plugins.rs`, `main.rs`): `get_alias` was marked dead code. Now called in the interactive shell loop (`raps shell`) to expand configured aliases before clap parses the command, making `raps plugin alias add` actually work end-to-end.

- **Cleaned up MCP auth guidance dead code** (`auth_guidance.rs`, `tools_oss.rs`): Removed `SETUP_INSTRUCTIONS`, `THREE_LEGGED_PROMPT`, `get_auth_state`, and unused `AuthState` fields (`has_client_id`, `has_client_secret`, `three_legged_expired`) and methods (`has_any_credentials`, `has_complete_2leg_credentials`). Removed stale `#[allow(dead_code)]` from `AuthRequirement`, `AuthState`, and `get_tool_auth_requirement` which ARE used in `docs.rs` and `tools_oss.rs`.

- **Fixed duplicate Cargo dependency** in `raps-cli/Cargo.toml`: Removed duplicate `glob.workspace = true` entry that caused `error: duplicate key` on cargo load.

## Result

`cargo check -p raps-cli` completes with **zero errors and zero warnings** — no `dead_code` warnings remain for the plugin module.

## Test plan

- [ ] `cargo check -p raps-cli` passes with no warnings
- [ ] `raps plugin list` works (lists plugins from PATH)
- [ ] `raps plugin alias add up "object upload"` followed by `raps shell` → type `up` → expands to `object upload`
- [ ] Configured hooks in `~/.config/raps/plugins.json` run before/after commands
- [ ] `raps pipeline run <file>` with `--resume`/`--reset`/`--reset-from` flags work correctly

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)