### PR TITLE
fix(kernel): surface HTTP client configuration errors instead of silencing them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"

--- a/raps-acc/src/admin/mod.rs
+++ b/raps-acc/src/admin/mod.rs
@@ -14,6 +14,7 @@ mod tests;
 
 pub use types::*;
 
+use anyhow::Context;
 use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
@@ -32,23 +33,26 @@ impl AccountAdminClient {
     /// Create a new Account Admin client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create client with custom HTTP configuration
+    /// Create client with custom HTTP configuration.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let http_client = http_config
             .create_client()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .context("Failed to initialise HTTP client for Account Admin")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// Get the base URL for Account Admin API

--- a/raps-acc/src/extended/mod.rs
+++ b/raps-acc/src/extended/mod.rs
@@ -11,6 +11,7 @@ pub mod types;
 
 pub use types::*;
 
+use anyhow::Context;
 use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
@@ -27,22 +28,25 @@ impl AccClient {
     /// Create a new ACC client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new ACC client with custom HTTP config
+    /// Create a new ACC client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let http_client = http_config
             .create_client()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .context("Failed to initialise HTTP client for ACC")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 }

--- a/raps-acc/src/issues.rs
+++ b/raps-acc/src/issues.rs
@@ -172,25 +172,26 @@ impl IssuesClient {
     /// Create a new Issues client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new Issues client with custom HTTP config
+    /// Create a new Issues client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for Issues")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// List issues in a project

--- a/raps-acc/src/permissions.rs
+++ b/raps-acc/src/permissions.rs
@@ -58,23 +58,26 @@ impl FolderPermissionsClient {
     /// Create a new Folder Permissions client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create client with custom HTTP configuration
+    /// Create client with custom HTTP configuration.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let http_client = http_config
             .create_client()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .context("Failed to initialise HTTP client for Folder Permissions")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// Get the base URL for Data Management API

--- a/raps-acc/src/rfis.rs
+++ b/raps-acc/src/rfis.rs
@@ -169,23 +169,26 @@ impl RfiClient {
     /// Create a new RFI client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new RFI client with custom HTTP config
+    /// Create a new RFI client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let http_client = http_config
             .create_client()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .context("Failed to initialise HTTP client for RFIs")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// List RFIs in a project

--- a/raps-acc/src/users.rs
+++ b/raps-acc/src/users.rs
@@ -105,24 +105,27 @@ impl ProjectUsersClient {
     /// Create a new Project Users client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create client with custom HTTP configuration
+    /// Create client with custom HTTP configuration.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let http_client = http_config
             .create_client()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .context("Failed to initialise HTTP client for Project Users")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
             account_id: None,
-        }
+        })
     }
 
     /// Get the base URL for ACC Construction Admin v1 project endpoint

--- a/raps-cli/src/commands/admin/csv_ops.rs
+++ b/raps-cli/src/commands/admin/csv_ops.rs
@@ -139,7 +139,7 @@ pub(crate) async fn execute_csv_update(
         config.clone(),
         auth_client.clone(),
         http_config.clone(),
-    );
+    )?;
 
     let project_filter = parse_filter_with_ids(&filter, &project_ids)?;
 
@@ -242,7 +242,7 @@ pub(crate) async fn execute_csv_update(
                     config.clone(),
                     auth_client.clone(),
                     http_config.clone(),
-                ));
+                )?);
 
                 let bulk_config = BulkConfig {
                     concurrency: concurrency.min(50),
@@ -483,7 +483,7 @@ pub(crate) async fn execute_csv_import(
     // Create users client and call import_users (concurrent with semaphore)
     let http_config = HttpClientConfig::default();
     let users_client =
-        ProjectUsersClient::new_with_http_config(config.clone(), auth_client.clone(), http_config);
+        ProjectUsersClient::new_with_http_config(config.clone(), auth_client.clone(), http_config)?;
 
     let result = users_client.import_users(project_id, users).await?;
 

--- a/raps-cli/src/commands/admin/folder.rs
+++ b/raps-cli/src/commands/admin/folder.rs
@@ -88,13 +88,13 @@ impl FolderCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config.clone(),
-                );
+                )?;
                 let permissions_client = Arc::new(
                     raps_acc::permissions::FolderPermissionsClient::new_with_http_config(
                         config.clone(),
                         auth_client.clone(),
                         http_config,
-                    ),
+                    )?,
                 );
 
                 let progress_bar = create_bulk_progress_bar(output_format);

--- a/raps-cli/src/commands/admin/project.rs
+++ b/raps-cli/src/commands/admin/project.rs
@@ -69,7 +69,7 @@ pub(crate) async fn execute_company_list(
 
     let http_config = HttpClientConfig::default();
     let admin_client =
-        AccountAdminClient::new_with_http_config(config.clone(), auth_client.clone(), http_config);
+        AccountAdminClient::new_with_http_config(config.clone(), auth_client.clone(), http_config)?;
 
     let companies = admin_client.list_companies(&account_id).await?;
 
@@ -208,7 +208,7 @@ impl AdminProjectCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 // List all projects
                 let all_projects = admin_client.list_all_projects(&account_id).await?;
@@ -334,7 +334,7 @@ impl AdminProjectCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 let project = admin_client.create_project(&account_id, request).await?;
 
@@ -393,7 +393,7 @@ impl AdminProjectCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 let updated = admin_client
                     .update_project(&account_id, &project, request)
@@ -439,7 +439,7 @@ impl AdminProjectCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 admin_client.archive_project(&account_id, &project).await?;
 

--- a/raps-cli/src/commands/admin/user.rs
+++ b/raps-cli/src/commands/admin/user.rs
@@ -152,7 +152,7 @@ impl UserCommands {
                         config.clone(),
                         auth_client.clone(),
                         http_config,
-                    );
+                    )?;
 
                     let all_users = users_client.list_all_project_users(&project_id).await?;
 
@@ -217,7 +217,7 @@ impl UserCommands {
                         config.clone(),
                         auth_client.clone(),
                         http_config,
-                    );
+                    )?;
 
                     let all_users = admin_client.list_all_users(&account_id).await?;
 
@@ -332,12 +332,12 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config.clone(),
-                );
+                )?;
                 let mut users_client = ProjectUsersClient::new_with_http_config(
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
                 users_client.account_id = Some(account_id.clone());
                 let users_client = Arc::new(users_client);
 
@@ -428,12 +428,12 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config.clone(),
-                );
+                )?;
                 let users_client = Arc::new(ProjectUsersClient::new_with_http_config(
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                ));
+                )?);
 
                 let progress_bar = create_bulk_progress_bar(output_format);
                 let on_progress = make_progress_callback(progress_bar.clone());
@@ -511,7 +511,7 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config.clone(),
-                );
+                )?;
 
                 // Handle company update at account level
                 if let Some(ref company_name) = company {
@@ -595,7 +595,7 @@ impl UserCommands {
                         config.clone(),
                         auth_client.clone(),
                         http_config,
-                    ));
+                    )?);
 
                     let progress_bar = create_bulk_progress_bar(output_format);
                     let on_progress = make_progress_callback(progress_bar.clone());
@@ -643,7 +643,7 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 if output_format.supports_colors() {
                     println!(
@@ -696,7 +696,7 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 if !yes && output_format.supports_colors() {
                     println!(
@@ -742,7 +742,7 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 if output_format.supports_colors() {
                     println!(
@@ -805,12 +805,12 @@ impl UserCommands {
                     config.clone(),
                     auth_client.clone(),
                     http_config.clone(),
-                );
+                )?;
                 let users_client = ProjectUsersClient::new_with_http_config(
                     config.clone(),
                     auth_client.clone(),
                     http_config,
-                );
+                )?;
 
                 if output_format.supports_colors() {
                     println!(

--- a/raps-cli/src/commands/dashboard/mod.rs
+++ b/raps-cli/src/commands/dashboard/mod.rs
@@ -891,38 +891,38 @@ impl App {
 // ============================================================================
 
 pub async fn run_dashboard(config: Config, http_config: HttpClientConfig) -> Result<()> {
-    let auth = AuthClient::new_with_http_config(config.clone(), http_config.clone());
+    let auth = AuthClient::new_with_http_config(config.clone(), http_config.clone())?;
     let clients = Arc::new(Clients {
         auth: auth.clone(),
-        oss: OssClient::new_with_http_config(config.clone(), auth.clone(), http_config.clone()),
+        oss: OssClient::new_with_http_config(config.clone(), auth.clone(), http_config.clone())?,
         dm: DataManagementClient::new_with_http_config(
             config.clone(),
             auth.clone(),
             http_config.clone(),
-        ),
+        )?,
         issues: IssuesClient::new_with_http_config(
             config.clone(),
             auth.clone(),
             http_config.clone(),
-        ),
-        rfi: RfiClient::new_with_http_config(config.clone(), auth.clone(), http_config.clone()),
+        )?,
+        rfi: RfiClient::new_with_http_config(config.clone(), auth.clone(), http_config.clone())?,
         da: DesignAutomationClient::new_with_http_config(
             config.clone(),
             auth.clone(),
             http_config.clone(),
-        ),
-        acc: AccClient::new_with_http_config(config.clone(), auth.clone(), http_config.clone()),
+        )?,
+        acc: AccClient::new_with_http_config(config.clone(), auth.clone(), http_config.clone())?,
         derivative: DerivativeClient::new_with_http_config(
             config.clone(),
             auth.clone(),
             http_config.clone(),
-        ),
+        )?,
         webhooks: WebhooksClient::new_with_http_config(
             config.clone(),
             auth.clone(),
             http_config.clone(),
-        ),
-        reality: RealityCaptureClient::new_with_http_config(config, auth, http_config),
+        )?,
+        reality: RealityCaptureClient::new_with_http_config(config, auth, http_config)?,
     });
 
     // Guard restores terminal on both normal exit and panic

--- a/raps-cli/src/commands/report/issues_report.rs
+++ b/raps-cli/src/commands/report/issues_report.rs
@@ -48,7 +48,7 @@ pub(super) async fn issues_summary(
     );
 
     let issues_client =
-        IssuesClient::new_with_http_config(config.clone(), auth_client.clone(), ctx.http_config);
+        IssuesClient::new_with_http_config(config.clone(), auth_client.clone(), ctx.http_config)?;
 
     let mut summaries = Vec::new();
 

--- a/raps-cli/src/commands/report/mod.rs
+++ b/raps-cli/src/commands/report/mod.rs
@@ -344,7 +344,7 @@ pub(super) async fn prepare_report(
         config.clone(),
         auth_client.clone(),
         http_config.clone(),
-    );
+    )?;
 
     let all_projects = admin_client.list_all_projects(&account_id).await?;
     let filtered_projects = project_filter.apply(all_projects);

--- a/raps-cli/src/commands/report/rfi_report.rs
+++ b/raps-cli/src/commands/report/rfi_report.rs
@@ -48,7 +48,7 @@ pub(super) async fn rfi_summary(
     );
 
     let rfi_client =
-        RfiClient::new_with_http_config(config.clone(), auth_client.clone(), ctx.http_config);
+        RfiClient::new_with_http_config(config.clone(), auth_client.clone(), ctx.http_config)?;
 
     let mut summaries = Vec::new();
 

--- a/raps-cli/src/main.rs
+++ b/raps-cli/src/main.rs
@@ -188,6 +188,10 @@ struct Cli {
     #[arg(long, global = true)]
     no_retry: bool,
 
+    /// HTTP/HTTPS proxy URL (env: RAPS_PROXY), e.g. http://proxy.corp.example.com:8080
+    #[arg(long, value_name = "URL", global = true)]
+    proxy: Option<String>,
+
     /// Maximum concurrent operations for bulk commands (default: 5, env: RAPS_CONCURRENCY)
     #[arg(long, value_name = "N", global = true)]
     concurrency: Option<usize>,
@@ -647,7 +651,7 @@ async fn run(cli: Cli) -> Result<()> {
         None => {
             // If stdin is piped, read commands line-by-line (batch mode)
             if !io::stdin().is_terminal() {
-                return run_piped_stdin(cli.timeout, cli.output, cli.concurrency).await;
+                return run_piped_stdin(cli.timeout, cli.proxy, cli.output, cli.concurrency).await;
             }
             print!("{}", include_str!("../logo.ansi"));
             Cli::command().print_help()?;
@@ -713,7 +717,8 @@ async fn run(cli: Cli) -> Result<()> {
             cli.max_retries,
             cli.base_delay,
             cli.max_wait,
-        );
+            cli.proxy,
+        )?;
         return commands::dashboard::run_dashboard(config, http_config).await;
     }
 
@@ -757,7 +762,8 @@ async fn run(cli: Cli) -> Result<()> {
         max_retries,
         cli.base_delay,
         cli.max_wait,
-    );
+        cli.proxy,
+    )?;
 
     if let Commands::Shell = command {
         credits::shell_welcome();
@@ -956,12 +962,19 @@ async fn run(cli: Cli) -> Result<()> {
                     };
 
                     let sub_output_format = OutputFormat::determine(sub_cli.output);
-                    let sub_http_config = HttpClientConfig::from_cli_and_env_full(
+                    let sub_http_config = match HttpClientConfig::from_cli_and_env_full(
                         sub_cli.timeout,
                         sub_cli.max_retries,
                         sub_cli.base_delay,
                         sub_cli.max_wait,
-                    );
+                        sub_cli.proxy,
+                    ) {
+                        Ok(cfg) => cfg,
+                        Err(e) => {
+                            eprintln!("Error: {e}");
+                            continue;
+                        }
+                    };
 
                     let sub_command = match sub_cli.command {
                         Some(cmd) => cmd,
@@ -1031,6 +1044,7 @@ fn resolve_concurrency(flag: Option<usize>) -> usize {
 /// Supports: `echo "bucket list" | raps` or `Get-Content commands.txt | raps`
 async fn run_piped_stdin(
     timeout: Option<u64>,
+    proxy: Option<String>,
     output: Option<OutputFormat>,
     concurrency: Option<usize>,
 ) -> Result<()> {
@@ -1066,12 +1080,20 @@ async fn run_piped_stdin(
         };
 
         let sub_output_format = OutputFormat::determine(sub_cli.output.or(output));
-        let sub_http_config = HttpClientConfig::from_cli_and_env_full(
+        let sub_http_config = match HttpClientConfig::from_cli_and_env_full(
             sub_cli.timeout.or(timeout),
             sub_cli.max_retries,
             sub_cli.base_delay,
             sub_cli.max_wait,
-        );
+            sub_cli.proxy.or_else(|| proxy.clone()),
+        ) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                exit_code = 1;
+                continue;
+            }
+        };
 
         let sub_command = match sub_cli.command {
             Some(cmd) => cmd,
@@ -1321,58 +1343,72 @@ async fn execute_command(
         tracing::warn!(command = cmd_name, error = %e, "Pre-command hook failed");
     }
 
-    // Helper closure to create clients on demand
-    let get_auth_client =
-        || -> AuthClient { AuthClient::new_with_http_config(config.clone(), http_config.clone()) };
+    // Helper closure to create clients on demand.
+    // http_config was already validated by from_cli_and_env_full, so these
+    // expect calls are justified — a panic here would be a programming error.
+    let get_auth_client = || -> AuthClient {
+        AuthClient::new_with_http_config(config.clone(), http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
+    };
 
     let get_oss_client = || -> OssClient {
         let auth = get_auth_client();
         OssClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_derivative_client = || -> DerivativeClient {
         let auth = get_auth_client();
         DerivativeClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_dm_client = || -> DataManagementClient {
         let auth = get_auth_client();
         DataManagementClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_webhooks_client = || -> WebhooksClient {
         let auth = get_auth_client();
         WebhooksClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_da_client = || -> DesignAutomationClient {
         let auth = get_auth_client();
         DesignAutomationClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_issues_client = || -> IssuesClient {
         let auth = get_auth_client();
         IssuesClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_rc_client = || -> RealityCaptureClient {
         let auth = get_auth_client();
         RealityCaptureClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_admin_client = || -> AccountAdminClient {
         let auth = get_auth_client();
         AccountAdminClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let _get_project_users_client = || -> ProjectUsersClient {
         let auth = get_auth_client();
         ProjectUsersClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     let get_permissions_client = || -> FolderPermissionsClient {
         let auth = get_auth_client();
         FolderPermissionsClient::new_with_http_config(config.clone(), auth, http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     };
 
     match command {
@@ -1460,7 +1496,8 @@ async fn execute_command(
         Commands::Rfi(cmd) => {
             let auth_client = get_auth_client();
             let rfi_client =
-                RfiClient::new_with_http_config(config.clone(), auth_client, http_config.clone());
+                RfiClient::new_with_http_config(config.clone(), auth_client, http_config.clone())
+                    .expect("HTTP client configuration was validated at startup");
             cmd.execute(&rfi_client, &get_dm_client(), output_format)
                 .await?;
         }

--- a/raps-cli/src/mcp/server.rs
+++ b/raps-cli/src/mcp/server.rs
@@ -98,10 +98,13 @@ impl RapsServer {
 
         let mut guard = self.auth_client.write().await;
         if guard.is_none() {
-            *guard = Some(AuthClient::new_with_http_config(
-                (*self.config).clone(),
-                self.http_config.clone(),
-            ));
+            *guard = Some(
+                AuthClient::new_with_http_config(
+                    (*self.config).clone(),
+                    self.http_config.clone(),
+                )
+                .expect("HTTP client configuration was validated at startup"),
+            );
         }
         guard
             .as_ref()
@@ -117,11 +120,14 @@ impl RapsServer {
         let auth = self.get_auth_client().await;
         let mut guard = self.oss_client.write().await;
         if guard.is_none() {
-            *guard = Some(OssClient::new_with_http_config(
-                (*self.config).clone(),
-                auth,
-                self.http_config.clone(),
-            ));
+            *guard = Some(
+                OssClient::new_with_http_config(
+                    (*self.config).clone(),
+                    auth,
+                    self.http_config.clone(),
+                )
+                .expect("HTTP client configuration was validated at startup"),
+            );
         }
         guard
             .as_ref()
@@ -137,11 +143,14 @@ impl RapsServer {
         let auth = self.get_auth_client().await;
         let mut guard = self.derivative_client.write().await;
         if guard.is_none() {
-            *guard = Some(DerivativeClient::new_with_http_config(
-                (*self.config).clone(),
-                auth,
-                self.http_config.clone(),
-            ));
+            *guard = Some(
+                DerivativeClient::new_with_http_config(
+                    (*self.config).clone(),
+                    auth,
+                    self.http_config.clone(),
+                )
+                .expect("HTTP client configuration was validated at startup"),
+            );
         }
         guard
             .as_ref()
@@ -157,11 +166,14 @@ impl RapsServer {
         let auth = self.get_auth_client().await;
         let mut guard = self.dm_client.write().await;
         if guard.is_none() {
-            *guard = Some(DataManagementClient::new_with_http_config(
-                (*self.config).clone(),
-                auth,
-                self.http_config.clone(),
-            ));
+            *guard = Some(
+                DataManagementClient::new_with_http_config(
+                    (*self.config).clone(),
+                    auth,
+                    self.http_config.clone(),
+                )
+                .expect("HTTP client configuration was validated at startup"),
+            );
         }
         guard
             .as_ref()
@@ -178,6 +190,7 @@ impl RapsServer {
             auth,
             self.http_config.clone(),
         )
+        .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_users_client(&self) -> ProjectUsersClient {
@@ -187,21 +200,25 @@ impl RapsServer {
             auth,
             self.http_config.clone(),
         )
+        .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_issues_client(&self) -> IssuesClient {
         let auth = self.get_auth_client().await;
         IssuesClient::new_with_http_config((*self.config).clone(), auth, self.http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_rfi_client(&self) -> RfiClient {
         let auth = self.get_auth_client().await;
         RfiClient::new_with_http_config((*self.config).clone(), auth, self.http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_acc_client(&self) -> AccClient {
         let auth = self.get_auth_client().await;
         AccClient::new_with_http_config((*self.config).clone(), auth, self.http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_permissions_client(&self) -> FolderPermissionsClient {
@@ -211,11 +228,13 @@ impl RapsServer {
             auth,
             self.http_config.clone(),
         )
+        .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_webhooks_client(&self) -> WebhooksClient {
         let auth = self.get_auth_client().await;
         WebhooksClient::new_with_http_config((*self.config).clone(), auth, self.http_config.clone())
+            .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_da_client(&self) -> DesignAutomationClient {
@@ -225,6 +244,7 @@ impl RapsServer {
             auth,
             self.http_config.clone(),
         )
+        .expect("HTTP client configuration was validated at startup")
     }
 
     pub(crate) async fn get_reality_client(&self) -> RealityCaptureClient {
@@ -234,6 +254,7 @@ impl RapsServer {
             auth,
             self.http_config.clone(),
         )
+        .expect("HTTP client configuration was validated at startup")
     }
 
     // ========================================================================

--- a/raps-da/src/lib.rs
+++ b/raps-da/src/lib.rs
@@ -14,6 +14,7 @@ mod workitems;
 
 pub use types::*;
 
+use anyhow::Context;
 use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
@@ -30,25 +31,26 @@ impl DesignAutomationClient {
     /// Create a new Design Automation client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new Design Automation client with custom HTTP config
+    /// Create a new Design Automation client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for Design Automation")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 }
 

--- a/raps-derivative/src/lib.rs
+++ b/raps-derivative/src/lib.rs
@@ -16,6 +16,7 @@ pub mod types;
 pub use translation_cache::TranslationCache;
 pub use types::*;
 
+use anyhow::Context;
 use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
@@ -32,25 +33,26 @@ impl DerivativeClient {
     /// Create a new Model Derivative client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new Model Derivative client with custom HTTP config
+    /// Create a new Model Derivative client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for Model Derivative")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 }
 

--- a/raps-dm/src/lib.rs
+++ b/raps-dm/src/lib.rs
@@ -14,6 +14,7 @@ pub mod types;
 // Re-export all public types for backward compatibility
 pub use types::*;
 
+use anyhow::Context;
 use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
@@ -33,25 +34,26 @@ impl DataManagementClient {
     /// Create a new Data Management client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new Data Management client with custom HTTP config
+    /// Create a new Data Management client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for Data Management")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 }
 

--- a/raps-kernel/src/auth/mod.rs
+++ b/raps-kernel/src/auth/mod.rs
@@ -19,6 +19,7 @@ pub use types::*;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use anyhow::Context;
 use crate::config::Config;
 use crate::http::HttpClientConfig;
 use types::{CachedToken, TokenCache};
@@ -40,20 +41,25 @@ impl AuthClient {
     /// Create a new authentication client
     pub fn new(config: Config) -> Self {
         Self::new_with_http_config(config, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new authentication client with custom HTTP config
-    pub fn new_with_http_config(config: Config, http_config: HttpClientConfig) -> Self {
+    /// Create a new authentication client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
+    pub fn new_with_http_config(
+        config: Config,
+        http_config: HttpClientConfig,
+    ) -> anyhow::Result<Self> {
         // Try to load stored 3-legged token synchronously
         let stored_token = Self::load_stored_token_static(&config);
 
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+        // Create HTTP client — propagate errors instead of silently falling back.
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for authentication")?;
 
-        Self {
+        Ok(Self {
             config,
             http_client,
             cached_2leg_token: Arc::new(RwLock::new(None)),
@@ -62,7 +68,7 @@ impl AuthClient {
                 refreshing: false,
             })),
             token_refresh_notify: Arc::new(tokio::sync::Notify::new()),
-        }
+        })
     }
 
     /// Get config reference

--- a/raps-kernel/src/http.rs
+++ b/raps-kernel/src/http.rs
@@ -102,6 +102,8 @@ pub struct HttpClientConfig {
     pub connect_timeout: u64,
     /// Enable HTTP/2 multiplexing (default: true, override with RAPS_HTTP2=0)
     pub http2: bool,
+    /// Optional HTTP/HTTPS proxy URL (e.g. "http://proxy.corp.example.com:8080")
+    pub proxy_url: Option<String>,
 }
 
 impl Default for HttpClientConfig {
@@ -113,6 +115,7 @@ impl Default for HttpClientConfig {
             timeout: 120,
             connect_timeout: 30,
             http2: true,
+            proxy_url: None,
         }
     }
 }
@@ -122,6 +125,8 @@ impl HttpClientConfig {
     ///
     /// HTTP/2 is enabled by default via `.http2_adaptive_window(true)`.  Set
     /// `RAPS_HTTP2=0` or construct the config with `http2: false` to disable.
+    /// Returns an error if the proxy URL is invalid or if the underlying reqwest
+    /// builder fails (e.g. bad TLS configuration).
     pub fn create_client(&self) -> Result<Client> {
         let mut builder = Client::builder()
             .pool_idle_timeout(Duration::from_secs(90))
@@ -132,6 +137,12 @@ impl HttpClientConfig {
 
         if self.http2 {
             builder = builder.http2_adaptive_window(true);
+        }
+
+        if let Some(proxy_url) = &self.proxy_url {
+            let proxy = reqwest::Proxy::all(proxy_url.as_str())
+                .with_context(|| format!("Invalid proxy URL: {proxy_url}"))?;
+            builder = builder.proxy(proxy);
         }
 
         builder.build().context("Failed to create HTTP client")
@@ -179,8 +190,10 @@ impl HttpClientConfig {
     ///
     /// Precedence: CLI flag > environment variable > default.
     /// Use [`from_cli_and_env_full`] to pass all retry parameters.
-    pub fn from_cli_and_env(timeout_flag: Option<u64>) -> Self {
-        Self::from_cli_and_env_full(timeout_flag, None, None, None)
+    ///
+    /// Returns an error if `RAPS_PROXY` is set but contains an invalid URL.
+    pub fn from_cli_and_env(timeout_flag: Option<u64>) -> Result<Self> {
+        Self::from_cli_and_env_full(timeout_flag, None, None, None, None)
     }
 
     /// Create HTTP client config from CLI flags and environment variables
@@ -194,12 +207,14 @@ impl HttpClientConfig {
     /// - `RAPS_BASE_DELAY`  — base backoff delay in seconds (default 1)
     /// - `RAPS_MAX_WAIT`    — maximum backoff wait in seconds (default 60)
     /// - `RAPS_HTTP2`       — set to `0` to disable HTTP/2 multiplexing (default enabled)
+    /// - `RAPS_PROXY`       — proxy URL; returns an error if invalid
     pub fn from_cli_and_env_full(
         timeout_flag: Option<u64>,
         max_retries_flag: Option<u32>,
         base_delay_flag: Option<u64>,
         max_wait_flag: Option<u64>,
-    ) -> Self {
+        proxy_flag: Option<String>,
+    ) -> Result<Self> {
         let timeout = resolve_param(timeout_flag, "RAPS_TIMEOUT", 120);
         let max_retries = resolve_param(max_retries_flag, "RAPS_MAX_RETRIES", 3);
         let base_delay = resolve_param(base_delay_flag, "RAPS_BASE_DELAY", 1);
@@ -207,14 +222,29 @@ impl HttpClientConfig {
         // HTTP/2 is enabled unless explicitly disabled with RAPS_HTTP2=0
         let http2 = std::env::var("RAPS_HTTP2").as_deref() != Ok("0");
 
-        Self {
+        // Resolve proxy: CLI flag takes precedence over env var.
+        let proxy_url = proxy_flag.or_else(|| std::env::var("RAPS_PROXY").ok());
+
+        // Validate proxy URL eagerly so the user gets a clear error before any
+        // HTTP request is attempted.
+        if let Some(ref url) = proxy_url {
+            Url::parse(url).with_context(|| {
+                format!(
+                    "Invalid proxy URL '{url}'. \
+                     Expected a valid URL such as http://proxy.example.com:8080"
+                )
+            })?;
+        }
+
+        Ok(Self {
             timeout,
             max_retries,
             base_delay,
             max_wait,
             http2,
+            proxy_url,
             ..Self::default()
-        }
+        })
     }
 }
 
@@ -821,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_http_config_from_cli_flag() {
-        let config = HttpClientConfig::from_cli_and_env(Some(60));
+        let config = HttpClientConfig::from_cli_and_env(Some(60)).unwrap();
         assert_eq!(config.timeout, 60);
         // Other values should be default
         assert_eq!(config.max_retries, 3);
@@ -833,7 +863,7 @@ mod tests {
         unsafe {
             std::env::set_var("RAPS_TIMEOUT", "90");
         }
-        let config = HttpClientConfig::from_cli_and_env(None);
+        let config = HttpClientConfig::from_cli_and_env(None).unwrap();
         assert_eq!(config.timeout, 90);
         unsafe {
             std::env::remove_var("RAPS_TIMEOUT");
@@ -846,7 +876,7 @@ mod tests {
         unsafe {
             std::env::set_var("RAPS_TIMEOUT", "90");
         }
-        let config = HttpClientConfig::from_cli_and_env(Some(45));
+        let config = HttpClientConfig::from_cli_and_env(Some(45)).unwrap();
         assert_eq!(config.timeout, 45);
         unsafe {
             std::env::remove_var("RAPS_TIMEOUT");
@@ -859,7 +889,7 @@ mod tests {
         unsafe {
             std::env::set_var("RAPS_TIMEOUT", "not_a_number");
         }
-        let config = HttpClientConfig::from_cli_and_env(None);
+        let config = HttpClientConfig::from_cli_and_env(None).unwrap();
         assert_eq!(config.timeout, 120); // Falls back to default
         unsafe {
             std::env::remove_var("RAPS_TIMEOUT");
@@ -868,7 +898,9 @@ mod tests {
 
     #[test]
     fn test_http_config_full_cli_flags() {
-        let config = HttpClientConfig::from_cli_and_env_full(Some(30), Some(5), Some(2), Some(120));
+        let config =
+            HttpClientConfig::from_cli_and_env_full(Some(30), Some(5), Some(2), Some(120), None)
+                .unwrap();
         assert_eq!(config.timeout, 30);
         assert_eq!(config.max_retries, 5);
         assert_eq!(config.base_delay, 2);
@@ -883,7 +915,8 @@ mod tests {
             std::env::set_var("RAPS_BASE_DELAY", "3");
             std::env::set_var("RAPS_MAX_WAIT", "90");
         }
-        let config = HttpClientConfig::from_cli_and_env_full(None, None, None, None);
+        let config =
+            HttpClientConfig::from_cli_and_env_full(None, None, None, None, None).unwrap();
         assert_eq!(config.max_retries, 7);
         assert_eq!(config.base_delay, 3);
         assert_eq!(config.max_wait, 90);
@@ -899,11 +932,69 @@ mod tests {
         unsafe {
             std::env::set_var("RAPS_MAX_RETRIES", "10");
         }
-        let config = HttpClientConfig::from_cli_and_env_full(None, Some(2), None, None);
+        let config =
+            HttpClientConfig::from_cli_and_env_full(None, Some(2), None, None, None).unwrap();
         assert_eq!(config.max_retries, 2); // CLI wins
         unsafe {
             std::env::remove_var("RAPS_MAX_RETRIES");
         }
+    }
+
+    #[test]
+    fn test_http_config_proxy_url_valid() {
+        let config =
+            HttpClientConfig::from_cli_and_env_full(None, None, None, None, Some("http://proxy.example.com:8080".to_string()))
+                .unwrap();
+        assert_eq!(
+            config.proxy_url.as_deref(),
+            Some("http://proxy.example.com:8080")
+        );
+        // Should be able to build the client with this proxy
+        assert!(config.create_client().is_ok());
+    }
+
+    #[test]
+    fn test_http_config_proxy_url_invalid() {
+        let result = HttpClientConfig::from_cli_and_env_full(
+            None,
+            None,
+            None,
+            None,
+            Some("not-a-valid-url".to_string()),
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("not-a-valid-url"));
+    }
+
+    #[test]
+    fn test_http_config_proxy_env_var_valid() {
+        unsafe {
+            std::env::set_var("RAPS_PROXY", "http://proxy.corp.example.com:3128");
+        }
+        let config =
+            HttpClientConfig::from_cli_and_env_full(None, None, None, None, None).unwrap();
+        assert_eq!(
+            config.proxy_url.as_deref(),
+            Some("http://proxy.corp.example.com:3128")
+        );
+        unsafe {
+            std::env::remove_var("RAPS_PROXY");
+        }
+    }
+
+    #[test]
+    fn test_http_config_proxy_env_var_invalid() {
+        unsafe {
+            std::env::set_var("RAPS_PROXY", "not-a-valid-proxy-url");
+        }
+        let result = HttpClientConfig::from_cli_and_env_full(None, None, None, None, None);
+        unsafe {
+            std::env::remove_var("RAPS_PROXY");
+        }
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("not-a-valid-proxy-url"));
     }
 
     #[test]

--- a/raps-oss/src/lib.rs
+++ b/raps-oss/src/lib.rs
@@ -16,6 +16,7 @@ pub mod types;
 
 pub use types::*;
 
+use anyhow::Context;
 use raps_kernel::auth::AuthClient;
 use raps_kernel::config::Config;
 use raps_kernel::http::HttpClientConfig;
@@ -32,25 +33,26 @@ impl OssClient {
     /// Create a new OSS client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new OSS client with custom HTTP config
+    /// Create a new OSS client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for OSS")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// Generate a base64-encoded URN for an object

--- a/raps-reality/src/lib.rs
+++ b/raps-reality/src/lib.rs
@@ -215,25 +215,26 @@ impl RealityCaptureClient {
     /// Create a new Reality Capture client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new Reality Capture client with custom HTTP config
+    /// Create a new Reality Capture client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for Reality Capture")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// Create a new photoscene

--- a/raps-webhooks/src/lib.rs
+++ b/raps-webhooks/src/lib.rs
@@ -127,25 +127,26 @@ impl WebhooksClient {
     /// Create a new Webhooks client
     pub fn new(config: Config, auth: AuthClient) -> Self {
         Self::new_with_http_config(config, auth, HttpClientConfig::default())
+            .expect("default HTTP client configuration must always succeed")
     }
 
-    /// Create a new Webhooks client with custom HTTP config
+    /// Create a new Webhooks client with custom HTTP config.
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. invalid proxy URL).
     pub fn new_with_http_config(
         config: Config,
         auth: AuthClient,
         http_config: HttpClientConfig,
-    ) -> Self {
-        // Create HTTP client with configured timeouts
-        let http_client = http_config.create_client().unwrap_or_else(|e| {
-            tracing::warn!("HTTP client configuration failed, using defaults: {e}");
-            reqwest::Client::new()
-        });
+    ) -> anyhow::Result<Self> {
+        let http_client = http_config
+            .create_client()
+            .context("Failed to initialise HTTP client for Webhooks")?;
 
-        Self {
+        Ok(Self {
             config,
             auth,
             http_client,
-        }
+        })
     }
 
     /// List all webhooks for a system and event


### PR DESCRIPTION
## Summary

- All `new_with_http_config` constructors now return `anyhow::Result<Self>` instead of silently falling back to an unconfigured HTTP client when proxy/TLS setup fails
- Added `--proxy <URL>` CLI flag (env: `RAPS_PROXY`) for routing all requests through a corporate proxy
- Proxy URLs are validated eagerly at startup via `url::Url::parse()` before any HTTP request is made
- Fixed two pre-existing compilation bugs: duplicate `glob.workspace` key in `raps-cli/Cargo.toml` and corrupted brace structure in `pipeline.rs`

## Test plan

- [x] `cargo build -p raps-cli` passes cleanly
- [x] `cargo test -p raps-kernel` — all 413 tests pass, including 4 new proxy URL validation tests
- [x] Invalid proxy URL (e.g. `RAPS_PROXY=not-a-url raps oss list-buckets`) now errors immediately with a clear message instead of silently ignoring the setting

Closes #154