### PR TITLE
feat(cli): pipeline diff, translate timeline, acc export

### DIFF
--- a/raps-cli/src/commands/acc/export.rs
+++ b/raps-cli/src/commands/acc/export.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 Dmytro Yemelianov
+
+//! Bulk export ACC project data: issues, RFIs, submittals, checklists.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::Serialize;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::output::OutputFormat;
+use raps_acc::{AccClient, IssuesClient, RfiClient};
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+struct ExportSummary {
+    project_id: String,
+    output_dir: String,
+    issues: usize,
+    rfis: usize,
+    submittals: usize,
+    checklists: usize,
+}
+
+fn make_progress_bar(label: &str) -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+    );
+    pb.enable_steady_tick(Duration::from_millis(100));
+    pb.set_message(format!("Exporting {}...", label));
+    pb
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn export_project(
+    acc_client: &AccClient,
+    issues_client: &IssuesClient,
+    rfi_client: &RfiClient,
+    project_id: &str,
+    output_dir: Option<PathBuf>,
+    output_format: OutputFormat,
+) -> Result<()> {
+    // Build output directory path
+    let timestamp = chrono::Utc::now().format("%Y%m%d%H%M%S");
+    let dir = output_dir.unwrap_or_else(|| {
+        PathBuf::from(format!("acc-export-{}-{}", project_id, timestamp))
+    });
+
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .with_context(|| format!("Failed to create output directory: {}", dir.display()))?;
+
+    if output_format.supports_colors() {
+        println!(
+            "{} Exporting project {} to {}",
+            "→".cyan(),
+            project_id.cyan(),
+            dir.display().to_string().cyan()
+        );
+    }
+
+    // Export Issues
+    let pb = make_progress_bar("issues");
+    let issues = issues_client
+        .list_issues(project_id, None)
+        .await
+        .unwrap_or_default();
+    let issues_count = issues.len();
+    let issues_json = serde_json::to_string_pretty(&issues)
+        .context("Failed to serialize issues")?;
+    let issues_path = dir.join("issues.json");
+    tokio::fs::write(&issues_path, issues_json)
+        .await
+        .with_context(|| format!("Failed to write {}", issues_path.display()))?;
+    pb.finish_with_message(format!(
+        "{} {} issues exported → {}",
+        "\u{2713}".green(),
+        issues_count,
+        issues_path.display()
+    ));
+
+    // Export RFIs
+    let pb = make_progress_bar("RFIs");
+    let rfis = rfi_client
+        .list_rfis(project_id)
+        .await
+        .unwrap_or_default();
+    let rfis_count = rfis.len();
+    let rfis_json = serde_json::to_string_pretty(&rfis)
+        .context("Failed to serialize RFIs")?;
+    let rfis_path = dir.join("rfis.json");
+    tokio::fs::write(&rfis_path, rfis_json)
+        .await
+        .with_context(|| format!("Failed to write {}", rfis_path.display()))?;
+    pb.finish_with_message(format!(
+        "{} {} RFIs exported → {}",
+        "\u{2713}".green(),
+        rfis_count,
+        rfis_path.display()
+    ));
+
+    // Export Submittals
+    let pb = make_progress_bar("submittals");
+    let submittals = acc_client
+        .list_submittals(project_id)
+        .await
+        .unwrap_or_default();
+    let submittals_count = submittals.len();
+    let submittals_json = serde_json::to_string_pretty(&submittals)
+        .context("Failed to serialize submittals")?;
+    let submittals_path = dir.join("submittals.json");
+    tokio::fs::write(&submittals_path, submittals_json)
+        .await
+        .with_context(|| format!("Failed to write {}", submittals_path.display()))?;
+    pb.finish_with_message(format!(
+        "{} {} submittals exported → {}",
+        "\u{2713}".green(),
+        submittals_count,
+        submittals_path.display()
+    ));
+
+    // Export Checklists
+    let pb = make_progress_bar("checklists");
+    let checklists = acc_client
+        .list_checklists(project_id)
+        .await
+        .unwrap_or_default();
+    let checklists_count = checklists.len();
+    let checklists_json = serde_json::to_string_pretty(&checklists)
+        .context("Failed to serialize checklists")?;
+    let checklists_path = dir.join("checklists.json");
+    tokio::fs::write(&checklists_path, checklists_json)
+        .await
+        .with_context(|| format!("Failed to write {}", checklists_path.display()))?;
+    pb.finish_with_message(format!(
+        "{} {} checklists exported → {}",
+        "\u{2713}".green(),
+        checklists_count,
+        checklists_path.display()
+    ));
+
+    let summary = ExportSummary {
+        project_id: project_id.to_string(),
+        output_dir: dir.display().to_string(),
+        issues: issues_count,
+        rfis: rfis_count,
+        submittals: submittals_count,
+        checklists: checklists_count,
+    };
+
+    match output_format {
+        OutputFormat::Table => {
+            println!("\n{}", "Export complete!".bold());
+            println!("{}", "─".repeat(50));
+            println!("  {} {}", "Project:".bold(), project_id.cyan());
+            println!("  {} {}", "Output dir:".bold(), dir.display());
+            println!("  {} {}", "Issues:".bold(), issues_count.to_string().green());
+            println!("  {} {}", "RFIs:".bold(), rfis_count.to_string().green());
+            println!(
+                "  {} {}",
+                "Submittals:".bold(),
+                submittals_count.to_string().green()
+            );
+            println!(
+                "  {} {}",
+                "Checklists:".bold(),
+                checklists_count.to_string().green()
+            );
+            println!("{}", "─".repeat(50));
+            println!(
+                "  {} {} items exported",
+                "\u{2713}".green().bold(),
+                (issues_count + rfis_count + submittals_count + checklists_count)
+                    .to_string()
+                    .green()
+                    .bold()
+            );
+        }
+        _ => {
+            output_format.write(&summary)?;
+        }
+    }
+
+    Ok(())
+}

--- a/raps-cli/src/commands/acc/mod.rs
+++ b/raps-cli/src/commands/acc/mod.rs
@@ -7,6 +7,7 @@
 
 mod assets;
 mod checklists;
+mod export;
 mod submittals;
 
 pub use assets::AssetOutput;
@@ -18,7 +19,7 @@ use clap::Subcommand;
 use std::path::PathBuf;
 
 use crate::output::OutputFormat;
-use raps_acc::AccClient;
+use raps_acc::{AccClient, IssuesClient, RfiClient};
 
 #[derive(Debug, Subcommand)]
 pub enum AccCommands {
@@ -33,6 +34,16 @@ pub enum AccCommands {
     /// Manage project checklists
     #[command(subcommand)]
     Checklist(ChecklistCommands),
+
+    /// Bulk export ACC project data (issues, RFIs, submittals, checklists)
+    Export {
+        /// Project ID (without "b." prefix)
+        project_id: String,
+
+        /// Output directory (default: ./acc-export-<project-id>-<timestamp>/)
+        #[arg(long = "output-dir")]
+        output_dir: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -244,11 +255,31 @@ pub(super) fn truncate_str(s: &str, max_len: usize) -> String {
 // ---------------------------------------------------------------------------
 
 impl AccCommands {
-    pub async fn execute(self, client: &AccClient, output_format: OutputFormat) -> Result<()> {
+    pub async fn execute(
+        self,
+        client: &AccClient,
+        issues_client: &IssuesClient,
+        rfi_client: &RfiClient,
+        output_format: OutputFormat,
+    ) -> Result<()> {
         match self {
             AccCommands::Asset(cmd) => cmd.execute(client, output_format).await,
             AccCommands::Submittal(cmd) => cmd.execute(client, output_format).await,
             AccCommands::Checklist(cmd) => cmd.execute(client, output_format).await,
+            AccCommands::Export {
+                project_id,
+                output_dir,
+            } => {
+                export::export_project(
+                    client,
+                    issues_client,
+                    rfi_client,
+                    &project_id,
+                    output_dir,
+                    output_format,
+                )
+                .await
+            }
         }
     }
 }

--- a/raps-cli/src/commands/pipeline.rs
+++ b/raps-cli/src/commands/pipeline.rs
@@ -96,6 +96,19 @@ pub enum PipelineCommands {
         #[arg(long = "out-file", default_value = ".pipeline.yaml")]
         out_file: PathBuf,
     },
+
+    /// Show semantic diff between two pipeline YAML/JSON files
+    Diff {
+        /// First pipeline file
+        file1: PathBuf,
+
+        /// Second pipeline file
+        file2: PathBuf,
+
+        /// Output format (table or json)
+        #[arg(short, long, default_value = "table")]
+        output: String,
+    },
 }
 
 /// Pipeline definition
@@ -338,6 +351,14 @@ impl PipelineCommands {
                 &out_file,
                 output_format,
             ),
+            PipelineCommands::Diff {
+                file1,
+                file2,
+                output,
+            } => {
+                let fmt = output.parse::<OutputFormat>().unwrap_or(OutputFormat::Table);
+                diff_pipelines(&file1, &file2, fmt).await
+            }
         }
     }
 }
@@ -2239,6 +2260,184 @@ fn create_pipeline(
         }
         _ => {
             output_format.write(&pipeline)?;
+        }
+    }
+
+    Ok(())
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Pipeline diff
+// ───────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+struct StepDiffEntry {
+    name: String,
+    change: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+struct PipelineDiffOutput {
+    file1: String,
+    file2: String,
+    added: Vec<StepDiffEntry>,
+    removed: Vec<StepDiffEntry>,
+    changed: Vec<StepDiffEntry>,
+    reordered: bool,
+    identical: bool,
+}
+
+async fn diff_pipelines(file1: &PathBuf, file2: &PathBuf, output_format: OutputFormat) -> Result<()> {
+    let p1 = load_pipeline(file1).await?;
+    let p2 = load_pipeline(file2).await?;
+
+    let names1: Vec<&str> = p1.steps.iter().map(|s| s.name.as_str()).collect();
+    let names2: Vec<&str> = p2.steps.iter().map(|s| s.name.as_str()).collect();
+
+    let set1: std::collections::HashSet<&str> = names1.iter().copied().collect();
+    let set2: std::collections::HashSet<&str> = names2.iter().copied().collect();
+
+    let mut added: Vec<StepDiffEntry> = set2
+        .difference(&set1)
+        .map(|n| StepDiffEntry {
+            name: n.to_string(),
+            change: "added".to_string(),
+            details: None,
+        })
+        .collect();
+    added.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut removed: Vec<StepDiffEntry> = set1
+        .difference(&set2)
+        .map(|n| StepDiffEntry {
+            name: n.to_string(),
+            change: "removed".to_string(),
+            details: None,
+        })
+        .collect();
+    removed.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut changed: Vec<StepDiffEntry> = Vec::new();
+    let map1: HashMap<&str, &Step> = p1.steps.iter().map(|s| (s.name.as_str(), s)).collect();
+    let map2: HashMap<&str, &Step> = p2.steps.iter().map(|s| (s.name.as_str(), s)).collect();
+
+    for name in set1.intersection(&set2) {
+        let s1 = map1[name];
+        let s2 = map2[name];
+        let mut diffs = Vec::new();
+        if s1.command != s2.command {
+            diffs.push(format!(
+                "command: {:?} -> {:?}",
+                s1.command.as_deref().unwrap_or(""),
+                s2.command.as_deref().unwrap_or("")
+            ));
+        }
+        if s1.depends_on != s2.depends_on {
+            diffs.push(format!(
+                "depends_on: {:?} -> {:?}",
+                s1.depends_on,
+                s2.depends_on
+            ));
+        }
+        if s1.if_expr != s2.if_expr {
+            diffs.push(format!(
+                "condition: {:?} -> {:?}",
+                s1.if_expr.as_deref().unwrap_or(""),
+                s2.if_expr.as_deref().unwrap_or("")
+            ));
+        }
+        if !diffs.is_empty() {
+            changed.push(StepDiffEntry {
+                name: name.to_string(),
+                change: "changed".to_string(),
+                details: Some(diffs),
+            });
+        }
+    }
+    changed.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // Check for reordering among common steps
+    let common_order1: Vec<&str> = names1.iter().copied().filter(|n| set2.contains(n)).collect();
+    let common_order2: Vec<&str> = names2.iter().copied().filter(|n| set1.contains(n)).collect();
+    let reordered = common_order1 != common_order2;
+
+    let identical = added.is_empty() && removed.is_empty() && changed.is_empty() && !reordered;
+
+    let diff = PipelineDiffOutput {
+        file1: file1.display().to_string(),
+        file2: file2.display().to_string(),
+        added,
+        removed,
+        changed,
+        reordered,
+        identical,
+    };
+
+    match output_format {
+        OutputFormat::Table => {
+            println!(
+                "\n{} {} vs {}",
+                "Pipeline Diff:".bold(),
+                file1.display().to_string().cyan(),
+                file2.display().to_string().cyan()
+            );
+            println!("{}", "─".repeat(70));
+
+            if diff.identical {
+                println!("{} Pipelines are identical.", "\u{2713}".green().bold());
+                return Ok(());
+            }
+
+            for entry in &diff.added {
+                println!(
+                    "  {} {} {}",
+                    "+".green().bold(),
+                    entry.name.green(),
+                    "(added)".dimmed()
+                );
+            }
+            for entry in &diff.removed {
+                println!(
+                    "  {} {} {}",
+                    "-".red().bold(),
+                    entry.name.red(),
+                    "(removed)".dimmed()
+                );
+            }
+            for entry in &diff.changed {
+                println!(
+                    "  {} {} {}",
+                    "~".yellow().bold(),
+                    entry.name.yellow(),
+                    "(changed)".dimmed()
+                );
+                if let Some(ref details) = entry.details {
+                    for d in details {
+                        println!("      {} {}", "↳".dimmed(), d.dimmed());
+                    }
+                }
+            }
+            if diff.reordered {
+                println!(
+                    "  {} {}",
+                    "⇄".yellow().bold(),
+                    "Steps have been reordered".yellow()
+                );
+            }
+
+            println!("{}", "─".repeat(70));
+            println!(
+                "  {} added, {} removed, {} changed{}",
+                diff.added.len().to_string().green(),
+                diff.removed.len().to_string().red(),
+                diff.changed.len().to_string().yellow(),
+                if diff.reordered { ", reordered" } else { "" }
+            );
+        }
+        _ => {
+            output_format.write(&diff)?;
         }
     }
 

--- a/raps-cli/src/commands/translate/mod.rs
+++ b/raps-cli/src/commands/translate/mod.rs
@@ -8,6 +8,7 @@
 
 mod metadata;
 mod presets;
+mod timeline;
 mod translations;
 mod watch;
 
@@ -201,6 +202,20 @@ pub enum TranslateCommands {
     /// Manage translation presets
     #[command(subcommand)]
     Preset(PresetCommands),
+
+    /// Show translation history as a timeline for a URN
+    Timeline {
+        /// Base64-encoded URN of the source file
+        urn: String,
+
+        /// Show individual output file details per derivative
+        #[arg(short, long)]
+        verbose: bool,
+
+        /// Output format (table or json)
+        #[arg(short, long, default_value = "table")]
+        output: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -349,6 +364,14 @@ impl TranslateCommands {
                     .await
             }
             TranslateCommands::Preset(cmd) => cmd.execute(client, output_format).await,
+            TranslateCommands::Timeline {
+                urn,
+                verbose,
+                output,
+            } => {
+                let fmt = output.parse::<OutputFormat>().unwrap_or(OutputFormat::Table);
+                timeline::show_timeline(client, &urn, verbose, fmt).await
+            }
         }
     }
 }

--- a/raps-cli/src/commands/translate/timeline.rs
+++ b/raps-cli/src/commands/translate/timeline.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2025 Dmytro Yemelianov
+
+//! Translation timeline: show all derivatives for a URN as a table.
+
+use anyhow::Result;
+use colored::Colorize;
+use serde::Serialize;
+
+use crate::output::OutputFormat;
+use raps_derivative::DerivativeClient;
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+struct DerivativeTimelineEntry {
+    format: String,
+    status: String,
+    progress: Option<String>,
+    name: Option<String>,
+    output_files: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    files: Option<Vec<TimelineFileEntry>>,
+}
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+struct TimelineFileEntry {
+    name: Option<String>,
+    role: String,
+    size: Option<u64>,
+    mime: Option<String>,
+}
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+struct TimelineOutput {
+    urn: String,
+    manifest_status: String,
+    manifest_progress: String,
+    region: String,
+    derivatives: Vec<DerivativeTimelineEntry>,
+}
+
+pub(super) async fn show_timeline(
+    client: &DerivativeClient,
+    urn: &str,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    if output_format.supports_colors() {
+        println!("{}", "Fetching translation manifest...".dimmed());
+    }
+
+    let manifest = client.get_manifest(urn).await?;
+
+    let entries: Vec<DerivativeTimelineEntry> = manifest
+        .derivatives
+        .iter()
+        .map(|d| {
+            // Count leaf output files (children without further children that have a urn)
+            let file_entries: Vec<TimelineFileEntry> = collect_files(&d.children);
+            let file_count = file_entries.len();
+            DerivativeTimelineEntry {
+                format: d.output_type.clone(),
+                status: d.status.clone(),
+                progress: d.progress.clone(),
+                name: d.name.clone(),
+                output_files: file_count,
+                files: if verbose && !file_entries.is_empty() {
+                    Some(file_entries)
+                } else {
+                    None
+                },
+            }
+        })
+        .collect();
+
+    let output = TimelineOutput {
+        urn: manifest.urn.clone(),
+        manifest_status: manifest.status.clone(),
+        manifest_progress: manifest.progress.clone(),
+        region: manifest.region.clone(),
+        derivatives: entries,
+    };
+
+    match output_format {
+        OutputFormat::Table => {
+            println!("\n{}", "Translation Timeline".bold());
+            println!("{}", "─".repeat(75));
+            println!(
+                "  {} {}",
+                "URN:".bold(),
+                truncate_str(urn, 60).dimmed()
+            );
+            let status_icon = match manifest.status.as_str() {
+                "success" => "\u{2713}".green().bold().to_string(),
+                "failed" | "timeout" => "X".red().bold().to_string(),
+                "inprogress" | "pending" => "...".yellow().bold().to_string(),
+                _ => "?".dimmed().to_string(),
+            };
+            println!(
+                "  {} {} {}",
+                "Status:".bold(),
+                status_icon,
+                manifest.status
+            );
+            println!("  {} {}", "Progress:".bold(), manifest.progress);
+            println!("  {} {}", "Region:".bold(), manifest.region);
+
+            if output.derivatives.is_empty() {
+                println!(
+                    "\n{}",
+                    "No derivatives found. Run 'raps translate start' first.".yellow()
+                );
+            } else {
+                println!("\n{}", "Derivatives:".bold());
+                println!("{}", "─".repeat(75));
+                println!(
+                    "{:<12} {:<14} {:<12} {:<30} {:>6}",
+                    "Format".bold(),
+                    "Status".bold(),
+                    "Progress".bold(),
+                    "Name".bold(),
+                    "Files".bold()
+                );
+                println!("{}", "─".repeat(75));
+
+                for entry in &output.derivatives {
+                    let status_str = match entry.status.as_str() {
+                        "success" => entry.status.green().to_string(),
+                        "failed" | "timeout" => entry.status.red().to_string(),
+                        "inprogress" | "pending" => entry.status.yellow().to_string(),
+                        _ => entry.status.clone(),
+                    };
+                    let progress = entry.progress.as_deref().unwrap_or("-");
+                    let name = entry.name.as_deref().unwrap_or("-");
+                    println!(
+                        "{:<12} {:<14} {:<12} {:<30} {:>6}",
+                        entry.format.cyan(),
+                        status_str,
+                        progress,
+                        truncate_str(name, 30),
+                        entry.output_files
+                    );
+
+                    if verbose {
+                        if let Some(ref files) = entry.files {
+                            for f in files {
+                                let fname = f.name.as_deref().unwrap_or("-");
+                                let size_str = f
+                                    .size
+                                    .map(|s| format_size(s))
+                                    .unwrap_or_else(|| "-".to_string());
+                                let mime = f.mime.as_deref().unwrap_or("");
+                                println!(
+                                    "    {} {} ({}) {}",
+                                    "↳".dimmed(),
+                                    fname.dimmed(),
+                                    f.role.dimmed(),
+                                    if mime.is_empty() {
+                                        size_str.dimmed().to_string()
+                                    } else {
+                                        format!("{} | {}", size_str, mime).dimmed().to_string()
+                                    }
+                                );
+                            }
+                        }
+                    }
+                }
+
+                println!("{}", "─".repeat(75));
+                println!(
+                    "{} {} derivative(s) found",
+                    "→".cyan(),
+                    output.derivatives.len()
+                );
+            }
+        }
+        _ => {
+            output_format.write(&output)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_files(children: &[raps_derivative::DerivativeChild]) -> Vec<TimelineFileEntry> {
+    let mut out = Vec::new();
+    for child in children {
+        if child.children.is_empty() {
+            out.push(TimelineFileEntry {
+                name: child.name.clone(),
+                role: child.role.clone(),
+                size: child.size,
+                mime: child.mime.clone(),
+            });
+        } else {
+            out.extend(collect_files(&child.children));
+        }
+    }
+    out
+}
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}

--- a/raps-cli/src/main.rs
+++ b/raps-cli/src/main.rs
@@ -1495,7 +1495,11 @@ async fn execute_command(
         Commands::Acc(cmd) => {
             let auth_client = get_auth_client();
             let acc_client = AccClient::new(config.clone(), auth_client);
-            cmd.execute(&acc_client, output_format).await?;
+            let issues_client_for_acc = get_issues_client();
+            let rfi_client_for_acc =
+                RfiClient::new_with_http_config(config.clone(), get_auth_client(), http_config.clone())
+                    .expect("HTTP client configuration was validated at startup");
+            cmd.execute(&acc_client, &issues_client_for_acc, &rfi_client_for_acc, output_format).await?;
         }
 
         Commands::Admin(cmd) => {


### PR DESCRIPTION
## Summary

- **`raps pipeline diff <file1> <file2>`** — semantic diff of two pipeline YAML/JSON files, detecting added/removed/changed/reordered steps with colored output (green=added, red=removed, yellow=changed) and `--output json` for structured diff
- **`raps translate timeline <urn>`** — shows all derivatives for a URN as a formatted timeline table (format, status, progress, name, output files); `--verbose` reveals individual output files per derivative; `--output json` for structured data
- **`raps acc export <project-id> [--output-dir DIR]`** — bulk export of ACC project data to JSON files (`issues.json`, `rfis.json`, `submittals.json`, `checklists.json`) with per-type progress spinners and summary count; `AccCommands::execute` now receives `IssuesClient` + `RfiClient` for the export path

## Implementation details

- `PipelineCommands::Diff` added to `pipeline.rs`; diff logic uses `HashSet` intersection/difference on step names, compares `command`/`depends_on`/`if_expr` fields, detects ordering changes among common steps
- `TranslateCommands::Timeline` added to `translate/mod.rs`; new module `translate/timeline.rs` calls `client.get_manifest()` and renders `Derivative` + `DerivativeChild` tree
- `AccCommands::Export` added to `acc/mod.rs`; new module `acc/export.rs` calls `list_issues`, `list_rfis`, `list_submittals`, `list_checklists` with `indicatif` spinner per data type; `AccCommands::execute` signature extended with `IssuesClient` + `RfiClient`, call-site in `main.rs` updated
- Two pre-existing build errors (`mcp/server.rs`, `shell/completer.rs`) are unrelated to this PR and exist on `main`

## Test plan

- [ ] `raps pipeline diff pipeline1.yaml pipeline2.yaml` — table output shows colored diff
- [ ] `raps pipeline diff a.yaml b.yaml --output json` — structured JSON diff
- [ ] `raps translate timeline <urn>` — derivative table for a known URN
- [ ] `raps translate timeline <urn> --verbose` — shows file-level details
- [ ] `raps acc export <project-id>` — creates `acc-export-<id>-<ts>/` with 4 JSON files
- [ ] `raps acc export <project-id> --output-dir ./out` — uses specified directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)