### PR TITLE
Demo-readiness: viewer-URL finish + scripted zero-to-production demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ docs/_build/
 # Archive directory
 archive/
 
+# Demo runtime state (scripts/demo)
+scripts/demo/.demo-state
+
 # RAPS history
 .raps_history
 .worktrees/

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,138 @@
+# RAPS Executive Demo
+
+The "wow beat": what normally takes **6 manual Autodesk APS API steps** (OAuth
+token exchange, base64 URN encoding, chunked multipart upload, status polling,
+retries, and finding a Viewer link) collapses into **4 clean `raps` commands**
+ending with a live Autodesk Viewer URL.
+
+```
+1. raps auth test                              # 2-legged OAuth, no token juggling
+2. raps bucket create --key <bucket>           # idempotent
+3. raps object upload <bucket> <model>         # auto-chunking + base64 URN printed
+4. raps translate start <urn> --format svf2 --watch   # live progress → Viewer URL
+```
+
+A scripted version of exactly this flow lives in `scripts/demo/`.
+
+---
+
+## 1. Prerequisites
+
+- `raps` on your `PATH`. Build a release binary for the smoothest demo:
+  ```bash
+  cargo build --release -p raps-cli
+  export PATH="$PWD/target/release:$PATH"   # so `raps` resolves to the fresh build
+  ```
+- `jq` and `base64` on `PATH` (used by the demo scripts).
+- An APS application with **OSS** + **Model Derivative** access from
+  <https://aps.autodesk.com/myapps>.
+
+## 2. Credentials / environment
+
+Set the two required env vars (or use a `.env` in the working directory — see
+`.env.example`):
+
+```bash
+export APS_CLIENT_ID=your_client_id
+export APS_CLIENT_SECRET=your_client_secret
+```
+
+Alternatively store them in a profile:
+
+```bash
+raps config set client_id "your_client_id"
+raps config set client_secret "your_client_secret"
+```
+
+Verify before recording:
+
+```bash
+raps auth test
+```
+
+> The 4-command flow uses **2-legged** OAuth (client credentials) only — no
+> browser login needed. `raps auth login` (3-legged) is only required for the
+> Data Management / ACC demos, not for this one.
+
+## 3. Run the demo
+
+### Option A — scripted (recommended for takes)
+
+```bash
+scripts/demo/run.sh
+```
+
+This runs all four commands against a tiny committed sample model
+(`scripts/demo/sample-cube.obj`), prints the base64 URN, shows a live spinner
+during translation, and finishes by printing the **Autodesk Viewer URL** for the
+translated SVF2 model. Use your own model with `--file`:
+
+```bash
+scripts/demo/run.sh --file /path/to/model.rvt
+```
+
+The bucket name is derived from the hostname (`raps-demo-<host>`) so it is stable
+across takes and `reset.sh` can find it.
+
+### Option B — single built-in command
+
+`raps demo model-pipeline` runs the same upload → translate → watch → summary
+flow end to end (it generates a synthetic cube if no `--file` is given) and now
+prints the Viewer URL in its summary:
+
+```bash
+raps demo model-pipeline --keep-bucket
+```
+
+### Option C — type the four commands live
+
+For a hand-typed take, run them one at a time. Copy the URN that `object upload`
+prints (it also prints the exact `translate` command to run next):
+
+```bash
+raps auth test
+raps bucket create --key raps-demo
+raps object upload raps-demo scripts/demo/sample-cube.obj
+raps translate start <paste-urn-here> --format svf2 --watch
+```
+
+## 4. Reset / teardown between takes
+
+```bash
+scripts/demo/reset.sh
+```
+
+Deletes the demo bucket (and its objects) and clears the local state file. Safe
+to run repeatedly. Override the target with `--bucket <name>`. If you used
+Option C with a custom bucket, pass it explicitly:
+
+```bash
+scripts/demo/reset.sh --bucket raps-demo
+```
+
+## 5. What the audience sees (output polish)
+
+- `object upload` prints the base64 URN under a bold yellow label plus the exact
+  `translate ... --watch` command to run next.
+- `translate start --watch` shows a single live spinner (`status=… progress=…`),
+  then a green check and a **`Viewer:` URL** (underlined). In non-color/quiet
+  mode it prints just the URL on its own line — easy to pipe or click.
+- The Viewer URL is `https://aps.autodesk.com/viewer?urn=<urn>` (the official APS
+  Viewer reference app). Opening it loads the translated model; on first use the
+  reference viewer prompts for APS login (`viewables:read`).
+
+---
+
+## TO BUILD (not yet implemented — documented per the demo brief)
+
+- **One-shot Viewer auto-open.** No `--open` flag exists to launch the Viewer URL
+  in a browser at the end of `translate --watch`. (A browser-open helper already
+  exists for 3-legged auth in `raps-kernel/src/auth/three_leg.rs` and could be
+  reused.) For now, click/paste the printed URL.
+- **Self-hosted viewer fallback.** `aps.autodesk.com/viewer` requires an
+  interactive APS login for OSS-hosted URNs. A zero-login experience would need a
+  small bundled viewer page that injects a `viewables:read` token. Out of scope
+  for a minimal additive change.
+- **`raps demo run` subcommand.** The scripted flow lives in `scripts/demo/` to
+  stay additive. Promoting it to a first-class `raps demo wow`/`run` subcommand
+  (mirroring `model-pipeline`) would remove the shell-script dependency.

--- a/raps-cli/src/commands/demo.rs
+++ b/raps-cli/src/commands/demo.rs
@@ -499,6 +499,10 @@ f 5//6 1//6 4//6 8//6
     println!("  Bucket:  {}", bucket_key);
     println!("  URN:     {}", urn);
     println!("  Format:  {}", args.format);
+    println!(
+        "  Viewer:  {}",
+        raps_derivative::viewer_url(&urn).cyan().underline()
+    );
 
     // Cleanup
     if !args.keep_bucket {

--- a/raps-cli/src/commands/object/upload.rs
+++ b/raps-cli/src/commands/object/upload.rs
@@ -217,6 +217,11 @@ pub(super) async fn upload_object(
                 "URN (for translation):".bold().yellow(),
                 output.urn
             );
+            println!(
+                "  {} raps translate start {} --watch",
+                "Next:".dimmed(),
+                output.urn.dimmed()
+            );
         }
         _ => {
             output_format.write(&output)?;

--- a/raps-cli/src/commands/translate/watch.rs
+++ b/raps-cli/src/commands/translate/watch.rs
@@ -60,8 +60,12 @@ pub async fn watch_translation(
                     "\u{2713}".green().bold(),
                     progress_msg
                 ));
+                let url = raps_derivative::viewer_url(urn);
                 if output_format.supports_colors() {
                     println!("{} Translation succeeded", "\u{2713}".green().bold());
+                    println!("\n  {} {}", "Viewer:".bold().cyan(), url.underline());
+                } else {
+                    println!("{}", url);
                 }
                 return Ok(());
             }

--- a/raps-derivative/src/types.rs
+++ b/raps-derivative/src/types.rs
@@ -386,9 +386,41 @@ pub struct PropertyPagination {
     pub limit: usize,
 }
 
+/// Build a shareable Autodesk APS Viewer URL for a translated (SVF2/SVF) model.
+///
+/// Returns a link to the official APS Viewer reference application, which loads
+/// any URN the authenticated APS application has access to. The URN is passed
+/// in the URL fragment exactly as APS expects it (base64url, no padding).
+///
+/// Note: viewing requires a valid `viewables:read` token in the browser; the
+/// reference viewer prompts for APS login on first use. For OSS-hosted models
+/// the URN is `urn:adsk.objects:os.object:<bucket>/<key>` base64url-encoded —
+/// the same value returned by `object upload` and accepted by `translate`.
+pub fn viewer_url(urn: &str) -> String {
+    format!("https://aps.autodesk.com/viewer?urn={}", urn.trim())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_viewer_url_format() {
+        let urn = "dXJuOmFkc2sub2JqZWN0czpvcy5vYmplY3Q6Yi9tLm9iag";
+        let url = viewer_url(urn);
+        assert_eq!(
+            url,
+            format!("https://aps.autodesk.com/viewer?urn={}", urn)
+        );
+        assert!(url.starts_with("https://"));
+        assert!(url.contains(urn));
+    }
+
+    #[test]
+    fn test_viewer_url_trims_whitespace() {
+        let url = viewer_url("  abc123  ");
+        assert_eq!(url, "https://aps.autodesk.com/viewer?urn=abc123");
+    }
 
     #[test]
     fn test_output_format_serialization() {

--- a/scripts/demo/reset.sh
+++ b/scripts/demo/reset.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# reset.sh — Return to a clean state between demo takes.
+#
+# Deletes the demo bucket (and its objects) created by run.sh, plus the local
+# state file. Safe to run repeatedly; missing resources are ignored.
+#
+# Usage:
+#   scripts/demo/reset.sh [--bucket <name>]
+#
+# With no --bucket, reads the bucket from scripts/demo/.demo-state (written by
+# run.sh). Falls back to the same host-derived name run.sh uses.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Show help before sourcing common.sh (which requires raps on PATH).
+for arg in "$@"; do
+    if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+        grep '^#' "${BASH_SOURCE[0]}" | grep -v '^#!' | sed 's/^# \{0,1\}//'
+        exit 0
+    fi
+done
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../use-cases/common.sh"
+
+STATE_FILE="$SCRIPT_DIR/.demo-state"
+BUCKET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bucket) BUCKET="$2"; shift 2 ;;
+        -h|--help)
+            grep '^#' "${BASH_SOURCE[0]}" | grep -v '^#!' | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) error "Unknown option: $1"; exit 2 ;;
+    esac
+done
+
+# Resolve bucket: --bucket > state file > host-derived default.
+if [[ -z "$BUCKET" && -f "$STATE_FILE" ]]; then
+    # shellcheck source=/dev/null
+    source "$STATE_FILE"
+fi
+if [[ -z "${BUCKET:-}" ]]; then
+    HOST_TAG="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | cut -c1-12)"
+    [[ -z "$HOST_TAG" ]] && HOST_TAG="local"
+    BUCKET="raps-demo-${HOST_TAG}"
+fi
+
+step "Resetting demo state (bucket: $BUCKET)"
+
+# Deleting the bucket removes its objects too. --yes skips the prompt.
+if raps bucket delete "$BUCKET" --yes 2>/dev/null; then
+    info "Deleted bucket: $BUCKET"
+else
+    dim "  (bucket not found or already deleted — nothing to do)"
+fi
+
+rm -f "$STATE_FILE"
+info "Clean. Ready for the next take."

--- a/scripts/demo/run.sh
+++ b/scripts/demo/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# run.sh — Executive demo: the "wow beat" for RAPS.
+#
+# Shows that 6 manual Autodesk APS API steps (OAuth, base64 URN encoding,
+# chunked upload, polling, retries) collapse into a handful of clean `raps`
+# commands ending in a live Autodesk Viewer URL.
+#
+#   1. raps auth test            (2-legged OAuth — no manual token juggling)
+#   2. raps bucket create        (idempotent)
+#   3. raps object upload        (auto-chunking + base64 URN, printed for you)
+#   4. raps translate start --watch   (live progress, ends with a Viewer URL)
+#
+# Usage:
+#   scripts/demo/run.sh [--file <path>] [--keep]
+#
+# Options:
+#   --file <path>   Model to upload (default: scripts/demo/sample-cube.obj)
+#   --keep          Skip teardown reminder note (bucket/object are left in place)
+#
+# Requirements: raps on PATH, APS_CLIENT_ID + APS_CLIENT_SECRET set (or a
+# configured profile). Run scripts/demo/reset.sh between takes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Show help before sourcing common.sh (which requires raps on PATH).
+for arg in "$@"; do
+    if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+        grep '^#' "${BASH_SOURCE[0]}" | grep -v '^#!' | sed 's/^# \{0,1\}//'
+        exit 0
+    fi
+done
+
+# Reuse the shared use-case helpers (info/step/error/check_auth, require raps+jq).
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../use-cases/common.sh"
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+
+FILE="$SCRIPT_DIR/sample-cube.obj"
+KEEP=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --file) FILE="$2"; shift 2 ;;
+        --keep) KEEP=true; shift ;;
+        -h|--help)
+            grep '^#' "${BASH_SOURCE[0]}" | grep -v '^#!' | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) error "Unknown option: $1"; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$FILE" ]]; then
+    error "Model file not found: $FILE"
+    exit 1
+fi
+
+# Stable bucket name per machine so reset.sh can find it. Lowercase + dash only
+# (OSS bucket key rules). Falls back to a fixed name if hostname is unusual.
+HOST_TAG="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | cut -c1-12)"
+[[ -z "$HOST_TAG" ]] && HOST_TAG="local"
+BUCKET="raps-demo-${HOST_TAG}"
+OBJECT_KEY="$(basename "$FILE")"
+STATE_FILE="$SCRIPT_DIR/.demo-state"
+
+echo
+step "RAPS demo — 4 commands, one Viewer URL"
+dim  "Bucket: $BUCKET   Model: $OBJECT_KEY"
+echo
+
+# ── 1. Auth (2-legged) ───────────────────────────────────────────────────────
+step "[1/4] raps auth test"
+check_auth
+
+# ── 2. Bucket (idempotent) ───────────────────────────────────────────────────
+step "[2/4] raps bucket create --key $BUCKET"
+raps bucket create --key "$BUCKET" 2>/dev/null \
+    || dim "  (bucket already exists — continuing)"
+
+# ── 3. Upload (auto-chunking + base64 URN) ───────────────────────────────────
+step "[3/4] raps object upload $BUCKET $FILE"
+raps object upload "$BUCKET" "$FILE"
+
+# Compute the same base64url URN raps prints, so we can drive translate + reset.
+URN="$(printf 'urn:adsk.objects:os.object:%s/%s' "$BUCKET" "$OBJECT_KEY" \
+        | base64 -w0 2>/dev/null | tr '+/' '-_' | tr -d '=')"
+
+# Persist state for reset.sh
+printf 'BUCKET=%s\nOBJECT_KEY=%s\nURN=%s\n' "$BUCKET" "$OBJECT_KEY" "$URN" > "$STATE_FILE"
+
+# ── 4. Translate with live progress → Viewer URL ─────────────────────────────
+step "[4/4] raps translate start <urn> --format svf2 --watch"
+raps translate start "$URN" --format svf2 --watch
+
+echo
+info "Done. The Viewer URL above opens the translated model in the Autodesk Viewer."
+if ! $KEEP; then
+    dim "Reset before the next take:  scripts/demo/reset.sh"
+fi

--- a/scripts/demo/sample-cube.obj
+++ b/scripts/demo/sample-cube.obj
@@ -1,0 +1,29 @@
+# RAPS demo sample model — a unit cube
+# Tiny text OBJ (safe to commit) used by scripts/demo/run.sh
+# Translates cleanly to SVF2 for the Autodesk Viewer.
+
+# Vertices
+v -1.0 -1.0  1.0
+v  1.0 -1.0  1.0
+v  1.0  1.0  1.0
+v -1.0  1.0  1.0
+v -1.0 -1.0 -1.0
+v  1.0 -1.0 -1.0
+v  1.0  1.0 -1.0
+v -1.0  1.0 -1.0
+
+# Normals
+vn  0.0  0.0  1.0
+vn  0.0  0.0 -1.0
+vn  0.0  1.0  0.0
+vn  0.0 -1.0  0.0
+vn  1.0  0.0  0.0
+vn -1.0  0.0  0.0
+
+# Faces
+f 1//1 2//1 3//1 4//1
+f 8//2 7//2 6//2 5//2
+f 4//3 3//3 7//3 8//3
+f 5//4 6//4 2//4 1//4
+f 2//5 6//5 7//5 3//5
+f 5//6 1//6 4//6 8//6


### PR DESCRIPTION
Makes the raps foundation demo land cleanly for recording. Based on `wip/spec-008-cli-safeguard` (the branch this was cut from) so the diff is just the demo work.

- `translate --watch` prints the APS **Viewer URL** on success (the demo payoff); `object upload` prints a copy-paste next-step hint.
- `scripts/demo/run.sh` (4-command flow) + `reset.sh` + a tiny sample model.
- `docs/DEMO.md` with setup/run/reset and required `APS_CLIENT_ID`/`APS_CLIENT_SECRET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)